### PR TITLE
5: One pod per service.

### DIFF
--- a/stack/deploy/deployer_factory.py
+++ b/stack/deploy/deployer_factory.py
@@ -24,7 +24,7 @@ from stack.deploy.compose.deploy_docker import (
 
 def getDeployerConfigGenerator(type: str, deployment_context):
     if type == "compose" or type is None:
-        return DockerDeployerConfigGenerator(type)
+        return DockerDeployerConfigGenerator(type, deployment_context)
     elif type == constants.k8s_deploy_type or type == constants.k8s_kind_deploy_type:
         return K8sDeployerConfigGenerator(type, deployment_context)
     else:

--- a/stack/deploy/deployment_context.py
+++ b/stack/deploy/deployment_context.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http:#www.gnu.org/licenses/>.
 
+import glob
 import hashlib
 import os
 from pathlib import Path
@@ -43,6 +44,9 @@ class DeploymentContext:
 
     def get_compose_dir(self):
         return self.deployment_dir.joinpath(constants.compose_dir_name)
+
+    def get_compose_files(self):
+        return glob.glob(f"{self.get_compose_dir()}/docker-compose-*.yml")
 
     def get_cluster_id(self):
         return self.id

--- a/stack/deploy/k8s/cluster_info.py
+++ b/stack/deploy/k8s/cluster_info.py
@@ -93,11 +93,12 @@ class ClusterInfo:
         services = self.get_services()
         for svc in services:
             if "ClusterIP" == svc.spec.type:
-                self.environment_variables.map[f"STACK_SVC_{svc.metadata.labels['service'].upper()}"] = f"{svc.metadata.name}.{self.namespace}.svc.cluster.local"
+                self.environment_variables.map[f"STACK_SVC_{svc.metadata.labels['service'].upper()}"] = (
+                    f"{svc.metadata.name}.{self.namespace}.svc.cluster.local"
+                )
 
         if opts.o.debug:
             print(f"Env vars: {self.environment_variables.map}")
-
 
     def get_ingress(self, use_tls=False, certificate=None, def_cluster_issuer="letsencrypt-prod"):
         # No ingress for a deployment that has no http-proxy defined, for now
@@ -178,7 +179,7 @@ class ClusterInfo:
                             service = client.V1Service(
                                 metadata=client.V1ObjectMeta(
                                     name=f"{self.app_name}-nodeport-{pod_port}",
-                                    labels={"app": self.app_name, "service": service_name}
+                                    labels={"app": self.app_name, "service": service_name},
                                 ),
                                 spec=client.V1ServiceSpec(
                                     type="NodePort",
@@ -197,7 +198,7 @@ class ClusterInfo:
                             service = client.V1Service(
                                 metadata=client.V1ObjectMeta(
                                     name=f"{self.app_name}-service-{service_name}-{raw_port}",
-                                    labels={"app": self.app_name, "service": service_name}
+                                    labels={"app": self.app_name, "service": service_name},
                                 ),
                                 spec=client.V1ServiceSpec(
                                     type="ClusterIP",

--- a/stack/deploy/k8s/cluster_info.py
+++ b/stack/deploy/k8s/cluster_info.py
@@ -44,7 +44,7 @@ from stack.deploy.k8s.helpers import env_var_name_for_service
 from stack.deploy.spec import Spec, Resources, ResourceLimits
 from stack.deploy.images import remote_tag_for_image_unique
 
-from stack.stack.deploy.k8s.helpers import DEFAULT_K8S_NAMESPACE
+from stack.deploy.k8s.helpers import DEFAULT_K8S_NAMESPACE
 
 DEFAULT_VOLUME_RESOURCES = Resources({"reservations": {"storage": "2Gi"}})
 

--- a/stack/deploy/k8s/cluster_info.py
+++ b/stack/deploy/k8s/cluster_info.py
@@ -93,7 +93,7 @@ class ClusterInfo:
         services = self.get_services()
         for svc in services:
             if "ClusterIP" == svc.spec.type:
-                self.environment_variables[f"STACK_SVC_{svc.metadata.labels['service'].upper()}"] = f"{svc.metadata['name']}.{self.namespace}.svc.cluster.local"
+                self.environment_variables.map[f"STACK_SVC_{svc.metadata.labels['service'].upper()}"] = f"{svc.metadata.name}.{self.namespace}.svc.cluster.local"
 
         if opts.o.debug:
             print(f"Env vars: {self.environment_variables.map}")

--- a/stack/deploy/k8s/cluster_info.py
+++ b/stack/deploy/k8s/cluster_info.py
@@ -333,7 +333,7 @@ class ClusterInfo:
 
                 merged_envs = (
                     merge_envs(
-                        envs_from_compose_file(service_info["environment"]),
+                        envs_from_compose_file(service_info["environment"], self.environment_variables.map),
                         self.environment_variables.map,
                     )
                     if "environment" in service_info

--- a/stack/deploy/k8s/deploy_k8s.py
+++ b/stack/deploy/k8s/deploy_k8s.py
@@ -20,7 +20,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from kubernetes import client, config
 from kubernetes.stream import stream
-from numpy.distutils.misc_util import all_strings
 
 from stack import constants
 from stack.deploy.deployer import Deployer, DeployerConfigGenerator

--- a/stack/deploy/k8s/deploy_k8s.py
+++ b/stack/deploy/k8s/deploy_k8s.py
@@ -34,7 +34,7 @@ from stack.deploy.k8s.helpers import (
     containers_in_pod,
     log_stream_from_string,
 )
-from stack.deploy.k8s.helpers import generate_kind_config
+from stack.deploy.k8s.helpers import generate_kind_config, DEFAULT_K8S_NAMESPACE
 from stack.deploy.k8s.cluster_info import ClusterInfo
 from stack.opts import opts
 from stack.deploy.deployment_context import DeploymentContext
@@ -61,7 +61,7 @@ class K8sDeployer(Deployer):
     core_api: client.CoreV1Api
     apps_api: client.AppsV1Api
     networking_api: client.NetworkingV1Api
-    k8s_namespace: str = "default"
+    k8s_namespace: str = DEFAULT_K8S_NAMESPACE
     kind_cluster_name: str
     skip_cluster_management: bool
     cluster_info: ClusterInfo
@@ -456,7 +456,7 @@ class K8sDeployer(Deployer):
             self.core_api.connect_get_namespaced_pod_exec,
             k8s_pod_name,
             container=service_name,
-            namespace="default",
+            namespace=self.k8s_namespace,
             command=command,
             tty=False,
             stdin=False,
@@ -483,7 +483,9 @@ class K8sDeployer(Deployer):
             try:
                 log_data = ""
                 for container in containers:
-                    container_log = self.core_api.read_namespaced_pod_log(k8s_pod_name, namespace="default", container=container)
+                    container_log = self.core_api.read_namespaced_pod_log(
+                        k8s_pod_name, namespace=self.k8s_namespace, container=container
+                    )
                     container_log_lines = container_log.splitlines()
                     for line in container_log_lines:
                         log_data += f"{container}: {line}\n"


### PR DESCRIPTION
Fix for #5, making each service a distinct pod in k8s.

Since (by default) we create ClusterIP services for exposed ports, to access a service across pods you'll need to know the service name.  In k8s, this is created at `start` time, based on the deployment cluster ID, service name in the stack, and the port number.  Something like: `bpi-ad3b7e6e1905ec48-service-db-5432`

Inside the cluster, you'll need to tack on the domain as `{namespace}.svc.cluster.local` leading to something like: `bpi-ad3b7e6e1905ec48-service-db-5432.default.svc.cluster.local`

This cannot be easily set beforehand by the user, so I've introduced a new environment variable scheme of `STACK_SVC_<NAME>` which will get populated automatically.

This allows us to set something in the compose file like:

```
GITEA__database__HOST: ${STACK_SVC_DB}:5432
```

This works for both k8s and docker, though by slightly difference mechanisms.  In the k8s case, we inject these into the environment loaded from `config.env`.  In docker, where the values are known and stable, we write them into config.env itself at `create` time.  (Docker takes a path to the env file rather than a map, and so the values need to be present in the file it reads.)