### PR TITLE
Improve default build to use the path from the stack container entry.

### DIFF
--- a/src/stack/build/build_types.py
+++ b/src/stack/build/build_types.py
@@ -18,12 +18,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping
 
+from stack.deploy.stack import Stack
 from stack.build.build_util import ContainerSpec
 
 
 @dataclass
 class BuildContext:
-    stack: str
+    stack: Stack
     container: ContainerSpec
     default_container_base_dir: Path
     container_build_env: Mapping[str,str]

--- a/src/stack/build/build_types.py
+++ b/src/stack/build/build_types.py
@@ -25,7 +25,7 @@ from stack.build.build_util import ContainerSpec
 class BuildContext:
     stack: str
     container: ContainerSpec
-    container_build_dir: Path
+    default_container_base_dir: Path
     container_build_env: Mapping[str,str]
     dev_root_path: str
 

--- a/src/stack/build/build_util.py
+++ b/src/stack/build/build_util.py
@@ -24,8 +24,9 @@ import subprocess
 from pathlib import Path
 from python_on_whales import DockerClient
 
+from stack.deploy.stack import get_parsed_stack_config
 from stack.opts import opts
-from stack.util import get_parsed_stack_config, warn_exit, get_yaml, error_exit
+from stack.util import warn_exit, get_yaml, error_exit
 
 
 class StackContainer:

--- a/src/stack/build/build_util.py
+++ b/src/stack/build/build_util.py
@@ -50,23 +50,27 @@ class ContainerSpec:
     name: str
     ref: str
     build: str
+    path: str
     file_path: str
 
-    def __init__(self, name: str=None, ref=None, build=None):
+    def __init__(self, name: str=None, ref=None, build=None, path=None):
         self.name = name
         self.ref = ref
         self.build = build
+        self.path = path
         self.file_path = None
 
     def __repr__(self):
         return str(self)
 
     def __str__(self):
-        ret = { "name": self.name, "ref": self.ref, "build": self.build, "file_path": self.file_path }
+        ret = { "name": self.name, "ref": self.ref, "build": self.build, "path": self.path, "file_path": self.file_path }
         return json.dumps(ret)
 
     def init_from_file(self, file_path: Path):
-        self.file_path = file_path
+        self.file_path = Path(file_path).as_posix()
+        self.path = Path(self.file_path).parent.as_posix()
+
         y = get_yaml().load(open(file_path, "r"))
         self.name = y["container"]["name"]
         self.ref = y["container"].get("ref")

--- a/src/stack/build/build_webapp.py
+++ b/src/stack/build/build_webapp.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from stack.build import prepare_containers
 from stack.build.build_types import BuildContext
 from stack.build.build_util import ContainerSpec
+from stack.deploy.stack import Stack
 from stack.deploy.webapp.util import determine_base_container, TimedLogger
 from stack.util import get_dev_root_path
 
@@ -69,7 +70,7 @@ def command(ctx, base_container, source_repo, force_rebuild, extra_build_args, t
         logger.log(f"Building base container: {base_container}")
 
     build_context_1 = BuildContext(
-        None,
+        Stack(None),
         ContainerSpec(base_container),
         container_build_dir,
         container_build_env,
@@ -99,7 +100,7 @@ def command(ctx, base_container, source_repo, force_rebuild, extra_build_args, t
         logger.log(f"Building app container: {tag}")
 
     build_context_2 = BuildContext(
-        None,
+        Stack(None),
         ContainerSpec(base_container),
         container_build_dir,
         container_build_env,

--- a/src/stack/build/prepare_containers.py
+++ b/src/stack/build/prepare_containers.py
@@ -160,7 +160,10 @@ def process_container(build_context: BuildContext) -> bool:
 def command(ctx, stack, include, exclude, git_ssh, build_policy, extra_build_args, no_pull, publish_images, image_registry, target_arch):
     """build (or fetch pre-built) stack containers"""
     check_if_stack_exists(stack)
-    stack = Stack(stack).init_from_file(os.path.join(stack, stack_file_name))
+    if stack_is_external(stack):
+        stack = Stack(stack).init_from_file(os.path.join(stack, stack_file_name))
+    else:
+        stack = Stack(stack)
 
     if build_policy not in BUILD_POLICIES:
         error_exit(f"{build_policy} is not one of {BUILD_POLICIES}")

--- a/src/stack/deploy/deploy.py
+++ b/src/stack/deploy/deploy.py
@@ -28,7 +28,6 @@ from stack import constants
 from stack.opts import opts
 from stack.util import (
     include_exclude_check,
-    get_parsed_stack_config,
     get_dev_root_path,
     stack_is_in_deployment,
     resolve_compose_file,
@@ -37,6 +36,7 @@ from stack.deploy.deployer import Deployer, DeployerException
 from stack.deploy.deployer_factory import getDeployer
 from stack.deploy.deploy_types import ClusterContext, DeployCommandContext
 from stack.deploy.deployment_context import DeploymentContext
+from stack.deploy.stack import get_parsed_stack_config
 
 
 def create_deploy_context(

--- a/src/stack/deploy/deploy.py
+++ b/src/stack/deploy/deploy.py
@@ -36,7 +36,7 @@ from stack.deploy.deployer import Deployer, DeployerException
 from stack.deploy.deployer_factory import getDeployer
 from stack.deploy.deploy_types import ClusterContext, DeployCommandContext
 from stack.deploy.deployment_context import DeploymentContext
-from stack.deploy.stack import get_parsed_stack_config
+from stack.deploy.stack import Stack, get_parsed_stack_config
 
 
 def create_deploy_context(
@@ -248,10 +248,10 @@ def _make_cluster_context(ctx, stack, include, exclude, cluster, env_file):
         all_pods = pod_list_file.read().splitlines()
 
     pods_in_scope = []
+    stack_config = Stack(stack)
     if stack:
         stack_config = get_parsed_stack_config(stack)
-        # TODO: syntax check the input here
-        pods_in_scope = stack_config["pods"]
+        pods_in_scope = stack_config.get_pods()
         cluster_config = stack_config["config"] if "config" in stack_config else None
     else:
         pods_in_scope = all_pods
@@ -259,7 +259,6 @@ def _make_cluster_context(ctx, stack, include, exclude, cluster, env_file):
 
     # Convert all pod definitions to v1.1 format
     pods_in_scope = _convert_to_new_format(pods_in_scope)
-
     if ctx.verbose:
         print(f"Pods: {pods_in_scope}")
 
@@ -270,8 +269,8 @@ def _make_cluster_context(ctx, stack, include, exclude, cluster, env_file):
     post_start_commands = []
     for pod in pods_in_scope:
         pod_name = pod["name"]
-        pod_repository = pod["repository"]
-        pod_path = pod["path"]
+        pod_repository = pod.get("repository", stack_config.get_repo_name())
+        pod_path = pod.get("path", ".")
         if include_exclude_check(pod_name, include, exclude):
             if pod_repository is None or pod_repository == "internal":
                 if deployment:

--- a/src/stack/deploy/deploy_util.py
+++ b/src/stack/deploy/deploy_util.py
@@ -18,8 +18,8 @@ from datetime import timedelta
 from typing import List, Any
 
 from stack.deploy.deploy_types import DeployCommandContext, VolumeMapping
+from stack.deploy.stack import get_parsed_stack_config
 from stack.util import (
-    get_parsed_stack_config,
     get_yaml,
     get_pod_list,
     resolve_compose_file,

--- a/src/stack/deploy/deployment_create.py
+++ b/src/stack/deploy/deployment_create.py
@@ -31,14 +31,13 @@ from stack.util import (
     get_yaml,
     pod_has_scripts,
     get_pod_script_paths,
-    get_plugin_code_paths,
     error_exit,
     env_var_map_from_file,
     resolve_config_dir,
 )
 from stack.deploy.deploy import create_deploy_context
 from stack.deploy.spec import Spec, MergedSpec
-from stack.deploy.stack import Stack
+from stack.deploy.stack import Stack, get_plugin_code_paths
 from stack.deploy.deployer_factory import getDeployerConfigGenerator
 from stack.deploy.deployment_context import DeploymentContext
 from stack.util import global_options2

--- a/src/stack/deploy/stack.py
+++ b/src/stack/deploy/stack.py
@@ -14,14 +14,22 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http:#www.gnu.org/licenses/>.
 
+import git
 import json
+import os
 import typing
 
 from pathlib import Path
+from typing import Set, List
 
-import git
-from stack.repos.setup_repositories import is_git_repo
-from stack.util import get_yaml, get_pod_file_path
+from stack.util import (
+    get_yaml,
+    get_stack_path,
+    is_git_repo,
+    error_exit,
+    get_dev_root_path,
+    resolve_compose_file,
+)
 from stack import constants
 
 
@@ -91,13 +99,13 @@ class Stack:
         return [p["name"] for p in pods]
 
     def load_pod_file(self, pod_name):
-        pod_file_path = get_pod_file_path(self.name, self, pod_name)
+        pod_file_path = get_pod_file_path(self, pod_name)
         if pod_file_path:
             return get_yaml().load(open(pod_file_path, "rt"))
         return None
 
     def get_pod_file_path(self, pod_name):
-        return get_pod_file_path(self.name, self, pod_name)
+        return get_pod_file_path(self, pod_name)
 
     def get_services(self):
         services = {}
@@ -172,5 +180,54 @@ class Stack:
     def dump(self, output_file_path):
         get_yaml().dump(self.obj, open(output_file_path, "wt"))
 
+    def get_plugin_code_paths(self) -> List[Path]:
+        result: Set[Path] = set()
+        for pod in self.get_pods():
+            if type(pod) is str:
+                result.add(get_stack_path(self.name))
+            else:
+                pod_root_dir = os.path.join(
+                    get_dev_root_path(None),
+                    pod.get("repository", self.get_repo_name()).split("@")[0].split("/")[-1],
+                    pod.get("path", "."),
+                )
+                result.add(Path(os.path.join(pod_root_dir, "stack")))
+
+        return list(result)
+
     def __str__(self):
         return json.dumps(self, default=vars, indent=2)
+
+
+# Caller can pass either the name of a stack, or a path to a stack file
+def get_parsed_stack_config(stack):
+    stack_file_path = get_stack_path(stack).joinpath(constants.stack_file_name)
+    if stack_file_path.exists():
+        return Stack(stack).init_from_file(stack_file_path)
+    # We try here to generate a useful diagnostic error
+    # First check if the stack directory is present
+    if stack_file_path.parent.exists():
+        error_exit(f"{constants.stack_file_name} file is missing from: {stack}")
+    error_exit(f"stack {stack} does not exist")
+
+
+def get_plugin_code_paths(stack) -> List[Path]:
+    parsed_stack = get_parsed_stack_config(stack)
+    return parsed_stack.get_plugin_code_paths()
+
+
+def get_pod_file_path(stack, pod_name: str):
+    result = None
+    pods = stack.get_pods()
+    if type(pods[0]) is str:
+        result = resolve_compose_file(stack.name, pod_name)
+    else:
+        for pod in pods:
+            if pod["name"] == pod_name:
+                pod_root_dir = os.path.join(
+                    get_dev_root_path(None),
+                    pod.get("repository", stack.get_repo_name()).split("@")[0].split("/")[-1],
+                    pod.get("path", "."),
+                )
+                result = os.path.join(pod_root_dir, "docker-compose.yml")
+    return result

--- a/src/stack/deploy/stack.py
+++ b/src/stack/deploy/stack.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http:#www.gnu.org/licenses/>.
 
 import git
-import json
 import os
 import typing
 
@@ -178,7 +177,12 @@ class Stack:
         return named_volumes
 
     def dump(self, output_file_path):
-        get_yaml().dump(self.obj, open(output_file_path, "wt"))
+        enhanced = self.obj.copy()
+        if self.get_repo_name():
+            for pod in enhanced["pods"]:
+                if "repository" not in pod:
+                    pod["repository"] = self.get_repo_name()
+        get_yaml().dump(enhanced, open(output_file_path, "wt"))
 
     def get_plugin_code_paths(self) -> List[Path]:
         result: Set[Path] = set()
@@ -196,7 +200,7 @@ class Stack:
         return list(result)
 
     def __str__(self):
-        return json.dumps(self, default=vars, indent=2)
+        return str(self.__dict__)
 
 
 # Caller can pass either the name of a stack, or a path to a stack file

--- a/src/stack/repos/setup_repositories.py
+++ b/src/stack/repos/setup_repositories.py
@@ -25,17 +25,18 @@ import git
 
 from git.exc import GitCommandError
 from tqdm import tqdm
+
+from stack.build.build_util import get_containers_in_scope, host_and_path_for_repo, branch_strip
+from stack.deploy.stack import get_parsed_stack_config
 from stack.opts import opts
 from stack.util import (
-    get_parsed_stack_config,
+    is_git_repo,
+    check_if_stack_exists,
+    get_dev_root_path,
     include_exclude_check,
     error_exit,
     warn_exit,
 )
-
-from stack.util import get_dev_root_path, check_if_stack_exists
-
-from stack.build.build_util import get_containers_in_scope, host_and_path_for_repo, branch_strip
 
 
 class GitProgress(git.RemoteProgress):
@@ -47,14 +48,6 @@ class GitProgress(git.RemoteProgress):
         self.pbar.total = max_count
         self.pbar.n = cur_count
         self.pbar.refresh()
-
-
-def is_git_repo(path):
-    try:
-        _ = git.Repo(path).git_dir
-        return True
-    except git.exc.InvalidGitRepositoryError:
-        return False
 
 
 # TODO: find a place for this in the context of click

--- a/src/stack/util.py
+++ b/src/stack/util.py
@@ -14,14 +14,17 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http:#www.gnu.org/licenses/>.
 
-from decouple import config
+import git
 import os.path
 import sys
 import ruamel.yaml
+
+from decouple import config
 from pathlib import Path
 from dotenv import dotenv_values
-from typing import Mapping, Set, List
-from stack.constants import stack_file_name, deployment_file_name
+from typing import Mapping
+
+from stack.constants import deployment_file_name
 
 STACK_USE_BUILTIN_STACK = "true" == os.environ.get("STACK_USE_BUILTIN_STACK", "false")
 
@@ -52,18 +55,6 @@ def get_dev_root_path(ctx):
     return dev_root_path
 
 
-# Caller can pass either the name of a stack, or a path to a stack file
-def get_parsed_stack_config(stack):
-    stack_file_path = get_stack_path(stack).joinpath(stack_file_name)
-    if stack_file_path.exists():
-        return get_yaml().load(open(stack_file_path, "r"))
-    # We try here to generate a useful diagnostic error
-    # First check if the stack directory is present
-    if stack_file_path.parent.exists():
-        error_exit(f"{stack_file_name} file is missing from: {stack}")
-    error_exit(f"stack {stack} does not exist")
-
-
 def get_pod_list(parsed_stack):
     # Handle both old and new format
     pods = parsed_stack["pods"]
@@ -74,19 +65,6 @@ def get_pod_list(parsed_stack):
         for pod in pods:
             result.append(pod["name"])
     return result
-
-
-def get_plugin_code_paths(stack) -> List[Path]:
-    parsed_stack = get_parsed_stack_config(stack)
-    pods = parsed_stack["pods"]
-    result: Set[Path] = set()
-    for pod in pods:
-        if type(pod) is str:
-            result.add(get_stack_path(stack))
-        else:
-            pod_root_dir = os.path.join(get_dev_root_path(None), pod["repository"].split("@")[0].split("/")[-1], pod["path"])
-            result.add(Path(os.path.join(pod_root_dir, "stack")))
-    return list(result)
 
 
 # # Find a config directory, looking first in any external stack
@@ -115,23 +93,6 @@ def resolve_compose_file(stack, pod_name: str):
         # If we don't find it fall through to the internal case
     compose_base = get_internal_compose_file_dir()
     return compose_base.joinpath(f"docker-compose-{pod_name}.yml")
-
-
-def get_pod_file_path(stack, parsed_stack, pod_name: str):
-    result = None
-    pods = parsed_stack["pods"]
-    if type(pods[0]) is str:
-        result = resolve_compose_file(stack, pod_name)
-    else:
-        for pod in pods:
-            if pod["name"] == pod_name:
-                pod_root_dir = os.path.join(
-                    get_dev_root_path(None),
-                    pod["repository"].split("@")[0].split("/")[-1],
-                    pod["path"],
-                )
-                result = os.path.join(pod_root_dir, "docker-compose.yml")
-    return result
 
 
 def get_pod_script_paths(parsed_stack, pod_name: str):
@@ -246,3 +207,11 @@ def env_var_map_from_file(file: Path, expand=True) -> Mapping[str, str]:
 def check_if_stack_exists(stack):
     if stack and not stack_is_external(stack) and not STACK_USE_BUILTIN_STACK:
         error_exit(f"Stack {stack} does not exist")
+
+
+def is_git_repo(path):
+    try:
+        _ = git.Repo(path).git_dir
+        return True
+    except git.exc.InvalidGitRepositoryError:
+        return False


### PR DESCRIPTION
Support using the default build script with a stack container that has a path.  For example:

```
name: todo
containers:
  - name: bpi/todo-frontend
    path: ./frontend/
  - name: bpi/todo-backend
    path: ./backend/
pods:
  - name: todo-list
    path: .
```

Previously, if it could not find a container.yml at the path specified, it would have tried to execute the default build from the top of the todo-list-app repo.  Now it will do so from the specified path for each container.