### PR TITLE
Remove extraneous build tag file and fix .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ stack.egg-info
 __pycache__
 *~
 package
-stack/data/build_tag.txt
+src/stack/data/build_tag.txt
 /build

--- a/src/stack/data/build_tag.txt
+++ b/src/stack/data/build_tag.txt
@@ -1,2 +1,0 @@
-# This file should be re-generated running: scripts/create_build_tag_file.sh script
-2.0.0-d531f73-202505011750


### PR DESCRIPTION
The build tag file had become committed into the repo, due to .gitignore having a stale path to that file. This fixes both issues.