### PR TITLE
Use fully qualified paths for repos

### DIFF
--- a/src/stack/base.py
+++ b/src/stack/base.py
@@ -76,11 +76,4 @@ class package_registry_stack(base_stack):
 
 
 def get_npm_registry_url():
-    # If an auth token is not defined, we assume the default should be the cerc registry
-    # If an auth token is defined, we assume the local gitea should be used.
-    default_npm_registry_url = (
-        "http://gitea.local:3000/api/packages/bozemanpass/npm/"
-        if get_config_setting("BPI_NPM_AUTH_TOKEN", default=None)
-        else "https://git.vdb.to/api/packages/bozemanpass/npm/"
-    )
-    return get_config_setting("STACK_NPM_REGISTRY_URL", default=default_npm_registry_url)
+    return get_config_setting("STACK_NPM_REGISTRY_URL", default="")

--- a/src/stack/build/build_util.py
+++ b/src/stack/build/build_util.py
@@ -193,29 +193,3 @@ def local_container_arch():
     if this_machine == "aarch64":
         this_machine = "arm64"
     return this_machine
-
-
-def image_registry_for_repo(repository):
-    host, path, _ = host_and_path_for_repo(repository)
-    if "github.com" == host:
-        return f"ghcr.io"
-    elif host:
-        return host
-    return None
-
-
-def branch_strip(s):
-    return s.split("@")[0]
-
-
-def host_and_path_for_repo(fully_qualified_repo):
-    repo_branch_split = fully_qualified_repo.split("@")
-    repo_branch = repo_branch_split[-1] if len(repo_branch_split) > 1 else None
-    repo_host_split = repo_branch_split[0].split("/")
-    # Legacy unqualified repo means github
-    if len(repo_host_split) == 2:
-        return "github.com", "/".join(repo_host_split), repo_branch
-    else:
-        if len(repo_host_split) == 3:
-            # First part is the host
-            return repo_host_split[0], "/".join(repo_host_split[1:]), repo_branch

--- a/src/stack/build/prepare_containers.py
+++ b/src/stack/build/prepare_containers.py
@@ -33,13 +33,13 @@ from stack import constants
 from stack.config.util import get_config_setting, get_dev_root_path, verbose_enabled
 from stack.base import get_npm_registry_url
 from stack.build.build_types import BuildContext
-from stack.build.build_util import ContainerSpec, get_containers_in_scope, container_exists_locally, container_exists_remotely, local_container_arch, host_and_path_for_repo, image_registry_for_repo
+from stack.build.build_util import ContainerSpec, get_containers_in_scope, container_exists_locally, container_exists_remotely, local_container_arch
 from stack.build.publish import publish_image
 from stack.constants import container_file_name, container_lock_file_name, stack_file_name
 from stack.deploy.stack import Stack, get_parsed_stack_config
 from stack.opts import opts
 from stack.repos.list_stack import resolve_stack
-from stack.repos.setup_repositories import fs_path_for_repo, process_repo
+from stack.repos.repo_util import host_and_path_for_repo, image_registry_for_repo, fs_path_for_repo, process_repo
 from stack.util import include_exclude_check, stack_is_external, error_exit, get_yaml, check_if_stack_exists
 
 
@@ -121,13 +121,14 @@ def process_container(build_context: BuildContext) -> bool:
     else:
         if opts.o.verbose:
             print(f"No script file found: {build_script_filename}, using default build script")
-        repo_dir = build_context.container.ref.split("/")[-1] if build_context.container.ref else build_context.container.name.split("/")[-1]
-        # TODO: make this less of a hack -- should be specified in some metadata somewhere
-        # Check if we have a repo for this container. If not, set the context dir to the container-build subdir
-        repo_full_path = os.path.join(build_context.dev_root_path, repo_dir)
+        if build_context.container.ref:
+            repo_full_path = fs_path_for_repo(build_context.container.ref)
+        else:
+            repo_full_path = build_context.stack.repo_path
+
         if build_context.container.path:
-            repo_full_path = os.path.join(repo_full_path, build_context.container.path)
-        repo_dir_or_build_dir = repo_full_path if os.path.exists(repo_full_path) else build_dir
+            repo_full_path = repo_full_path.joinpath(build_context.container.path)
+        repo_dir_or_build_dir = repo_full_path if repo_full_path.exists() else build_dir
         build_command = (
             os.path.join(build_context.default_container_base_dir, "default-build.sh")
             + f" {default_container_tag} {repo_dir_or_build_dir}"

--- a/src/stack/deploy/deployment_create.py
+++ b/src/stack/deploy/deployment_create.py
@@ -541,7 +541,7 @@ def create_operation(deployment_command_context, parsed_spec: Spec | MergedSpec,
         config_dirs = {pod}
         config_dirs = config_dirs.union(extra_config_dirs)
         for config_dir in config_dirs:
-            source_config_dir = resolve_config_dir(parsed_stack.name, config_dir)
+            source_config_dir = resolve_config_dir(parsed_stack, config_dir)
             if os.path.exists(source_config_dir):
                 destination_config_dir = deployment_dir_path.joinpath("config", config_dir)
                 # If the same config dir appears in multiple pods, it may already have been copied
@@ -555,14 +555,14 @@ def create_operation(deployment_command_context, parsed_spec: Spec | MergedSpec,
             _copy_files_to_directory(script_paths, destination_script_dir)
         if parsed_spec.is_kubernetes_deployment():
             for configmap in parsed_spec.get_configmaps():
-                source_config_dir = resolve_config_dir(parsed_stack.name, configmap)
+                source_config_dir = resolve_config_dir(parsed_stack, configmap)
                 if os.path.exists(source_config_dir):
                     destination_config_dir = deployment_dir_path.joinpath("configmaps", configmap)
                     copytree(source_config_dir, destination_config_dir, dirs_exist_ok=True)
         else:
             # TODO: We should probably only do this if the volume is marked :ro.
             for volume_name, volume_path in parsed_spec.get_volumes().items():
-                source_config_dir = resolve_config_dir(parsed_stack.name, volume_name)
+                source_config_dir = resolve_config_dir(parsed_stack, volume_name)
                 # Only copy if the source exists and is _not_ empty.
                 if os.path.exists(source_config_dir) and os.listdir(source_config_dir):
                     destination_config_dir = deployment_dir_path.joinpath(volume_path)

--- a/src/stack/deploy/stack.py
+++ b/src/stack/deploy/stack.py
@@ -26,10 +26,11 @@ from stack.config.util import get_dev_root_path
 from stack.util import (
     get_yaml,
     get_stack_path,
-    is_git_repo,
     error_exit,
     resolve_compose_file,
 )
+
+from stack.repos.repo_util import host_and_path_for_repo, is_git_repo
 
 
 class Stack:
@@ -306,7 +307,8 @@ def get_pod_file_path(stack, pod_name: str):
 
 
 def determine_fs_path_for_stack(stack_ref, stack_path):
-    return Path(os.path.sep.join([str(get_dev_root_path()), os.path.basename(stack_ref), str(stack_path)]))
+    repo_host, repo_path, repo_branch = host_and_path_for_repo(stack_ref)
+    return Path(os.path.sep.join([str(get_dev_root_path()), str(repo_host), str(repo_path), str(stack_path)]))
 
 
 def get_pod_script_paths(parsed_stack, pod_name: str):

--- a/src/stack/deploy/stack.py
+++ b/src/stack/deploy/stack.py
@@ -256,7 +256,7 @@ class Stack:
             else:
                 pod_root_dir = os.path.join(
                     get_dev_root_path(),
-                    pod.get("repository", self.get_repo_name()).split("@")[0].split("/")[-1],
+                    pod.get("repository", self.get_repo_name()).split("@")[0],
                     pod.get("path", "."),
                 )
                 result.add(Path(os.path.join(pod_root_dir, "stack")))
@@ -293,13 +293,13 @@ def get_pod_file_path(stack, pod_name: str):
     result = None
     pods = stack.get_pods()
     if type(pods[0]) is str:
-        result = resolve_compose_file(stack.name, pod_name)
+        result = resolve_compose_file(str(stack.file_path.parent), pod_name)
     else:
         for pod in pods:
             if pod["name"] == pod_name:
                 pod_root_dir = os.path.join(
                     get_dev_root_path(),
-                    pod.get("repository", stack.get_repo_name()).split("@")[0].split("/")[-1],
+                    pod.get("repository", stack.get_repo_name()).split("@")[0],
                     pod.get("path", "."),
                 )
                 result = os.path.join(pod_root_dir, f"{constants.compose_file_prefix}.yml")
@@ -319,7 +319,7 @@ def get_pod_script_paths(parsed_stack, pod_name: str):
             if pod["name"] == pod_name:
                 pod_root_dir = os.path.join(
                     get_dev_root_path(),
-                    pod.get("repository", parsed_stack.get_repo_name()).split("@")[0].split("/")[-1],
+                    pod.get("repository", parsed_stack.get_repo_name()).split("@")[0],
                     pod.get("path", "."),
                 )
                 if "pre_start_command" in pod:

--- a/src/stack/repos/fetch_stack.py
+++ b/src/stack/repos/fetch_stack.py
@@ -22,9 +22,9 @@ import click
 
 from git import exc
 
-from stack.build.build_util import host_and_path_for_repo
 from stack.config.util import get_config_setting, get_dev_root_path, verbose_enabled
 from stack.repos.setup_repositories import process_repo
+from stack.repos.repo_util import host_and_path_for_repo
 from stack.util import error_exit
 
 

--- a/src/stack/repos/repo_util.py
+++ b/src/stack/repos/repo_util.py
@@ -26,7 +26,6 @@ from stack.config.util import get_dev_root_path
 from stack.opts import opts
 
 
-
 class GitProgress(git.RemoteProgress):
     def __init__(self):
         super().__init__()

--- a/src/stack/repos/repo_util.py
+++ b/src/stack/repos/repo_util.py
@@ -1,0 +1,194 @@
+# Copyright © 2024 Vulcanize
+# Copyright © 2025 Bozeman Pass, Inc.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http:#www.gnu.org/licenses/>.
+
+import git
+import os
+import sys
+
+from git.exc import GitCommandError
+from tqdm import tqdm
+from pathlib import Path
+
+from stack.config.util import get_dev_root_path
+from stack.opts import opts
+
+
+
+class GitProgress(git.RemoteProgress):
+    def __init__(self):
+        super().__init__()
+        self.pbar = tqdm(unit="B", ascii=True, unit_scale=True)
+
+    def update(self, op_code, cur_count, max_count=None, message=""):
+        self.pbar.total = max_count
+        self.pbar.n = cur_count
+        self.pbar.refresh()
+
+
+def branch_strip(s):
+    return s.split("@")[0]
+
+
+def host_and_path_for_repo(fully_qualified_repo):
+    repo_branch_split = fully_qualified_repo.split("@")
+    repo_branch = repo_branch_split[-1] if len(repo_branch_split) > 1 else None
+    repo_host_split = repo_branch_split[0].split("/")
+    # Legacy unqualified repo means github
+    if len(repo_host_split) == 2:
+        return "github.com", "/".join(repo_host_split), repo_branch
+    else:
+        if len(repo_host_split) == 3:
+            # First part is the host
+            return repo_host_split[0], "/".join(repo_host_split[1:]), repo_branch
+
+
+def image_registry_for_repo(repository):
+    host, path, _ = host_and_path_for_repo(repository)
+    if "github.com" == host:
+        return "ghcr.io"
+    elif host:
+        return host
+    return None
+
+
+def is_git_repo(path):
+    try:
+        _ = git.Repo(path).git_dir
+        return True
+    except:  # noqa: E722
+        pass
+
+    return False
+
+
+# See: https://stackoverflow.com/questions/18659425/get-git-current-branch-tag-name
+def _get_repo_current_branch_or_tag(full_filesystem_repo_path):
+    current_repo_branch_or_tag = "***UNDETERMINED***"
+    is_branch = False
+    try:
+        current_repo_branch_or_tag = git.Repo(full_filesystem_repo_path).active_branch.name
+        is_branch = True
+    except TypeError:
+        # This means that the current ref is not a branch, so possibly a tag
+        # Let's try to get the tag
+        try:
+            current_repo_branch_or_tag = git.Repo(full_filesystem_repo_path).git.describe("--tags", "--exact-match")
+            # Note that git is asymmetric -- the tag you told it to check out may not be the one
+            # you get back here (if there are multiple tags associated with the same commit)
+        except GitCommandError:
+            # If there is no matching branch or tag checked out, just use the current SHA
+            current_repo_branch_or_tag = git.Repo(full_filesystem_repo_path).commit("HEAD").hexsha
+    return current_repo_branch_or_tag, is_branch
+
+
+def fs_path_for_repo(fully_qualified_repo, dev_root_path=get_dev_root_path()):
+    repo_host, repo_path, repo_branch = host_and_path_for_repo(fully_qualified_repo)
+    return Path(os.path.join(dev_root_path, repo_host, repo_path))
+
+
+# TODO: fix the messy arg list here
+def process_repo(pull, check_only, git_ssh, dev_root_path, branches_array, fully_qualified_repo):
+    if opts.o.verbose:
+        print(f"Processing repo: {fully_qualified_repo}")
+    repo_host, repo_path, repo_branch = host_and_path_for_repo(fully_qualified_repo)
+    git_ssh_prefix = f"git@{repo_host}:"
+    git_http_prefix = f"https://{repo_host}/"
+    full_github_repo_path = f"{git_ssh_prefix if git_ssh else git_http_prefix}{repo_path}"
+    full_filesystem_repo_path = Path(os.path.join(dev_root_path, repo_host, repo_path))
+    full_filesystem_repo_path.parent.mkdir(parents=True, exist_ok=True)
+    is_present = os.path.isdir(full_filesystem_repo_path)
+    (current_repo_branch_or_tag, is_branch) = (
+        _get_repo_current_branch_or_tag(full_filesystem_repo_path) if is_present else (None, None)
+    )
+    if not opts.o.quiet:
+        present_text = (
+            f"already exists active {'branch' if is_branch else 'ref'}: {current_repo_branch_or_tag}"
+            if is_present
+            else "Needs to be fetched"
+        )
+        print(f"Checking: {full_filesystem_repo_path}: {present_text}")
+    # Quick check that it's actually a repo
+    if is_present:
+        if not is_git_repo(full_filesystem_repo_path):
+            print(f"Error: {full_filesystem_repo_path} does not contain a valid git repository")
+            sys.exit(1)
+        else:
+            if pull:
+                if opts.o.verbose:
+                    print(f"Running git pull for {full_filesystem_repo_path}")
+                if not check_only:
+                    if is_branch:
+                        git_repo = git.Repo(full_filesystem_repo_path)
+                        origin = git_repo.remotes.origin
+                        origin.pull(progress=None if opts.o.quiet else GitProgress())
+                    else:
+                        print("skipping pull because this repo is not on a branch")
+                else:
+                    print("(git pull skipped)")
+    if not is_present:
+        # Clone
+        if opts.o.verbose:
+            print(f"Running git clone for {full_github_repo_path} into {full_filesystem_repo_path}")
+        if not opts.o.dry_run:
+            git.Repo.clone_from(
+                full_github_repo_path,
+                full_filesystem_repo_path,
+                progress=None if opts.o.quiet else GitProgress(),
+            )
+        else:
+            print("(git clone skipped)")
+    # Checkout the requested branch, if one was specified
+    branch_to_checkout = None
+    if branches_array:
+        # Find the current repo in the branches list
+        print("Checking")
+        for repo_branch in branches_array:
+            repo_branch_tuple = repo_branch.split(" ")
+            if repo_branch_tuple[0] == branch_strip(fully_qualified_repo):
+                # checkout specified branch
+                branch_to_checkout = repo_branch_tuple[1]
+    else:
+        branch_to_checkout = repo_branch
+
+    if branch_to_checkout:
+        if current_repo_branch_or_tag is None or (
+            current_repo_branch_or_tag and (current_repo_branch_or_tag != branch_to_checkout)
+        ):
+            if not opts.o.quiet:
+                print(f"switching to branch {branch_to_checkout} in repo {repo_path}")
+            git_repo = git.Repo(full_filesystem_repo_path)
+            # git checkout works for both branches and tags
+            git_repo.git.checkout(branch_to_checkout)
+        else:
+            if not opts.o.quiet:
+                print(f"repo {repo_path} is already on branch/tag {branch_to_checkout}")
+
+    return full_filesystem_repo_path
+
+
+def parse_branches(branches_string):
+    if branches_string:
+        result_array = []
+        branches_directives = branches_string.split(",")
+        for branch_directive in branches_directives:
+            split_directive = branch_directive.split("@")
+            if len(split_directive) != 2:
+                print(f"Error: branch specified is not valid: {branch_directive}")
+                sys.exit(1)
+            result_array.append(f"{split_directive[0]} {split_directive[1]}")
+        return result_array
+    else:
+        return None

--- a/src/stack/repos/setup_repositories.py
+++ b/src/stack/repos/setup_repositories.py
@@ -78,8 +78,7 @@ def _get_repo_current_branch_or_tag(full_filesystem_repo_path):
 
 def fs_path_for_repo(fully_qualified_repo, dev_root_path):
     repo_host, repo_path, repo_branch = host_and_path_for_repo(fully_qualified_repo)
-    repoName = repo_path.split("/")[-1]
-    return Path(os.path.join(dev_root_path, repoName))
+    return Path(os.path.join(dev_root_path, repo_host, repo_path))
 
 
 # TODO: fix the messy arg list here
@@ -90,8 +89,8 @@ def process_repo(pull, check_only, git_ssh, dev_root_path, branches_array, fully
     git_ssh_prefix = f"git@{repo_host}:"
     git_http_prefix = f"https://{repo_host}/"
     full_github_repo_path = f"{git_ssh_prefix if git_ssh else git_http_prefix}{repo_path}"
-    repoName = repo_path.split("/")[-1]
-    full_filesystem_repo_path = os.path.join(dev_root_path, repoName)
+    full_filesystem_repo_path = Path(os.path.join(dev_root_path, repo_host, repo_path))
+    full_filesystem_repo_path.parent.mkdir(parents=True, exist_ok=True)
     is_present = os.path.isdir(full_filesystem_repo_path)
     (current_repo_branch_or_tag, is_branch) = (
         _get_repo_current_branch_or_tag(full_filesystem_repo_path) if is_present else (None, None)

--- a/src/stack/repos/setup_repositories.py
+++ b/src/stack/repos/setup_repositories.py
@@ -196,12 +196,12 @@ def command(ctx, stack, include, exclude, git_ssh, check_only, pull, branches):
     top_stack = resolve_stack(stack)
     required_stacks = []
     if top_stack.is_super_stack():
-        for stack_refs in stack.get_required_stacks():
+        for stack_refs in top_stack.get_required_stacks():
             try:
                 repo_path = process_repo(pull, check_only, git_ssh, get_dev_root_path(), None, stack_refs[constants.ref_key])
             except git.exc.GitCommandError as error:
                 error_exit(f"\n******* git command returned error exit status:\n{error}")
-            required_stacks.append(os.path.sep.join([repo_path, stack_refs[constants.path_key]]))
+            required_stacks.append(repo_path.joinpath(stack_refs[constants.path_key]))
     else:
         required_stacks.append(top_stack)
 

--- a/src/stack/repos/setup_repositories.py
+++ b/src/stack/repos/setup_repositories.py
@@ -19,161 +19,20 @@
 
 import click
 import os
-import sys
 import git
 
-from git.exc import GitCommandError
-from tqdm import tqdm
-from pathlib import Path
 
 from stack import constants
-from stack.build.build_util import get_containers_in_scope, host_and_path_for_repo, branch_strip
+from stack.build.build_util import get_containers_in_scope
 from stack.config.util import get_config_setting, get_dev_root_path
 from stack.deploy.stack import get_parsed_stack_config
 from stack.opts import opts
 from stack.repos.list_stack import resolve_stack
+from stack.repos.repo_util import process_repo, parse_branches, branch_strip
 from stack.util import (
-    is_git_repo,
     include_exclude_check,
     error_exit,
 )
-
-
-class GitProgress(git.RemoteProgress):
-    def __init__(self):
-        super().__init__()
-        self.pbar = tqdm(unit="B", ascii=True, unit_scale=True)
-
-    def update(self, op_code, cur_count, max_count=None, message=""):
-        self.pbar.total = max_count
-        self.pbar.n = cur_count
-        self.pbar.refresh()
-
-
-# TODO: find a place for this in the context of click
-# parser = argparse.ArgumentParser(
-#    epilog="Config provided either in .env or settings.ini or env vars: STACK_REPO_BASE_DIR (defaults to ~/bpi)"
-#   )
-
-
-# See: https://stackoverflow.com/questions/18659425/get-git-current-branch-tag-name
-def _get_repo_current_branch_or_tag(full_filesystem_repo_path):
-    current_repo_branch_or_tag = "***UNDETERMINED***"
-    is_branch = False
-    try:
-        current_repo_branch_or_tag = git.Repo(full_filesystem_repo_path).active_branch.name
-        is_branch = True
-    except TypeError:
-        # This means that the current ref is not a branch, so possibly a tag
-        # Let's try to get the tag
-        try:
-            current_repo_branch_or_tag = git.Repo(full_filesystem_repo_path).git.describe("--tags", "--exact-match")
-            # Note that git is asymmetric -- the tag you told it to check out may not be the one
-            # you get back here (if there are multiple tags associated with the same commit)
-        except GitCommandError:
-            # If there is no matching branch or tag checked out, just use the current SHA
-            current_repo_branch_or_tag = git.Repo(full_filesystem_repo_path).commit("HEAD").hexsha
-    return current_repo_branch_or_tag, is_branch
-
-
-def fs_path_for_repo(fully_qualified_repo, dev_root_path):
-    repo_host, repo_path, repo_branch = host_and_path_for_repo(fully_qualified_repo)
-    return Path(os.path.join(dev_root_path, repo_host, repo_path))
-
-
-# TODO: fix the messy arg list here
-def process_repo(pull, check_only, git_ssh, dev_root_path, branches_array, fully_qualified_repo):
-    if opts.o.verbose:
-        print(f"Processing repo: {fully_qualified_repo}")
-    repo_host, repo_path, repo_branch = host_and_path_for_repo(fully_qualified_repo)
-    git_ssh_prefix = f"git@{repo_host}:"
-    git_http_prefix = f"https://{repo_host}/"
-    full_github_repo_path = f"{git_ssh_prefix if git_ssh else git_http_prefix}{repo_path}"
-    full_filesystem_repo_path = Path(os.path.join(dev_root_path, repo_host, repo_path))
-    full_filesystem_repo_path.parent.mkdir(parents=True, exist_ok=True)
-    is_present = os.path.isdir(full_filesystem_repo_path)
-    (current_repo_branch_or_tag, is_branch) = (
-        _get_repo_current_branch_or_tag(full_filesystem_repo_path) if is_present else (None, None)
-    )
-    if not opts.o.quiet:
-        present_text = (
-            f"already exists active {'branch' if is_branch else 'ref'}: {current_repo_branch_or_tag}"
-            if is_present
-            else "Needs to be fetched"
-        )
-        print(f"Checking: {full_filesystem_repo_path}: {present_text}")
-    # Quick check that it's actually a repo
-    if is_present:
-        if not is_git_repo(full_filesystem_repo_path):
-            print(f"Error: {full_filesystem_repo_path} does not contain a valid git repository")
-            sys.exit(1)
-        else:
-            if pull:
-                if opts.o.verbose:
-                    print(f"Running git pull for {full_filesystem_repo_path}")
-                if not check_only:
-                    if is_branch:
-                        git_repo = git.Repo(full_filesystem_repo_path)
-                        origin = git_repo.remotes.origin
-                        origin.pull(progress=None if opts.o.quiet else GitProgress())
-                    else:
-                        print("skipping pull because this repo is not on a branch")
-                else:
-                    print("(git pull skipped)")
-    if not is_present:
-        # Clone
-        if opts.o.verbose:
-            print(f"Running git clone for {full_github_repo_path} into {full_filesystem_repo_path}")
-        if not opts.o.dry_run:
-            git.Repo.clone_from(
-                full_github_repo_path,
-                full_filesystem_repo_path,
-                progress=None if opts.o.quiet else GitProgress(),
-            )
-        else:
-            print("(git clone skipped)")
-    # Checkout the requested branch, if one was specified
-    branch_to_checkout = None
-    if branches_array:
-        # Find the current repo in the branches list
-        print("Checking")
-        for repo_branch in branches_array:
-            repo_branch_tuple = repo_branch.split(" ")
-            if repo_branch_tuple[0] == branch_strip(fully_qualified_repo):
-                # checkout specified branch
-                branch_to_checkout = repo_branch_tuple[1]
-    else:
-        branch_to_checkout = repo_branch
-
-    if branch_to_checkout:
-        if current_repo_branch_or_tag is None or (
-            current_repo_branch_or_tag and (current_repo_branch_or_tag != branch_to_checkout)
-        ):
-            if not opts.o.quiet:
-                print(f"switching to branch {branch_to_checkout} in repo {repo_path}")
-            git_repo = git.Repo(full_filesystem_repo_path)
-            # git checkout works for both branches and tags
-            git_repo.git.checkout(branch_to_checkout)
-        else:
-            if not opts.o.quiet:
-                print(f"repo {repo_path} is already on branch/tag {branch_to_checkout}")
-
-    return full_filesystem_repo_path
-
-
-def parse_branches(branches_string):
-    if branches_string:
-        result_array = []
-        branches_directives = branches_string.split(",")
-        for branch_directive in branches_directives:
-            split_directive = branch_directive.split("@")
-            if len(split_directive) != 2:
-                print(f"Error: branch specified is not valid: {branch_directive}")
-                sys.exit(1)
-            result_array.append(f"{split_directive[0]} {split_directive[1]}")
-        return result_array
-    else:
-        return None
 
 
 @click.command()

--- a/src/stack/util.py
+++ b/src/stack/util.py
@@ -65,8 +65,11 @@ def get_pod_list(parsed_stack):
 # and if not found there, internally
 def resolve_config_dir(stack, config_dir_name: str):
     if stack_is_external(stack):
-        # First try looking in the external stack for the compose file
-        config_base = Path(stack).parent.parent.joinpath("config")
+        print(stack.file_path.parent, config_dir_name)
+        if stack.repo_path:
+            config_base = stack.repo_path.joinpath("config")
+        else:
+            config_base = stack.file_path.parent.parent.parent.joinpath("config")
         proposed_dir = config_base.joinpath(config_dir_name)
         if proposed_dir.exists():
             return proposed_dir

--- a/src/stack/util.py
+++ b/src/stack/util.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http:#www.gnu.org/licenses/>.
 
-import git
 import os.path
 import sys
 import ruamel.yaml
@@ -181,16 +180,6 @@ def check_if_stack_exists(stack):
         error_exit("Error: Missing option '--stack'.")
     if stack and not stack_is_external(stack) and not STACK_USE_BUILTIN_STACK:
         error_exit(f"Stack {stack} does not exist")
-
-
-def is_git_repo(path):
-    try:
-        _ = git.Repo(path).git_dir
-        return True
-    except:  # noqa: E722
-        pass
-
-    return False
 
 
 def is_primitive(obj):

--- a/src/stack/util.py
+++ b/src/stack/util.py
@@ -130,7 +130,7 @@ def stack_is_external(stack):
         return stack.exists()
     elif isinstance(stack, str):
         return Path(stack).exists()
-    elif stack:  # a Stack
+    elif stack and stack.file_path:  # a Stack
         return stack.file_path.exists()
     return False
 

--- a/tests/deploy/run-deploy-test.sh
+++ b/tests/deploy/run-deploy-test.sh
@@ -97,17 +97,16 @@ mkdir -p $STACK_REPO_BASE_DIR
 # Test bringing the test container up and down
 # with and without volume removal
 
-STACK_NAME="example-todo-list"
-STACK_PATH="$STACK_REPO_BASE_DIR/$STACK_NAME/stacks/todo"
+STACK_NAME="todo"
 
-$TEST_TARGET_SO fetch stack bozemanpass/$STACK_NAME
-$TEST_TARGET_SO fetch repositories --stack $STACK_PATH
-$TEST_TARGET_SO build containers --stack $STACK_PATH
+$TEST_TARGET_SO fetch stack bozemanpass/example-todo-list
+$TEST_TARGET_SO fetch repositories --stack $STACK_NAME
+$TEST_TARGET_SO build containers --stack $STACK_NAME
 
 # Basic test of creating a deployment
 test_deployment_dir=$STACK_REPO_BASE_DIR/test-deployment-dir
 test_deployment_spec=$STACK_REPO_BASE_DIR/test-deployment-spec.yml
-$TEST_TARGET_SO init --stack $STACK_PATH --output $test_deployment_spec --map-ports-to-host localhost-same
+$TEST_TARGET_SO init --stack $STACK_NAME --output $test_deployment_spec --map-ports-to-host localhost-same
 # Check the file now exists
 if [ ! -f "$test_deployment_spec" ]; then
     echo "deploy init test: spec file not present"

--- a/tests/k8s-deploy/run-deploy-test.sh
+++ b/tests/k8s-deploy/run-deploy-test.sh
@@ -141,18 +141,17 @@ mkdir -p $STACK_REPO_BASE_DIR
 # Test bringing the test container up and down
 # with and without volume removal
 
-STACK_NAME="example-todo-list"
-STACK_PATH="$STACK_REPO_BASE_DIR/$STACK_NAME/stacks/todo"
+STACK_NAME="todo"
 
-$TEST_TARGET_SO fetch stack bozemanpass/$STACK_NAME
-$TEST_TARGET_SO fetch repositories --stack $STACK_PATH
-$TEST_TARGET_SO build containers --stack $STACK_PATH
+$TEST_TARGET_SO fetch stack bozemanpass/example-todo-list
+$TEST_TARGET_SO fetch repositories --stack $STACK_NAME
+$TEST_TARGET_SO build containers --stack $STACK_NAME
 
 # Basic test of creating a deployment
 test_deployment_dir=$STACK_REPO_BASE_DIR/test-deployment-dir
 test_deployment_spec=$STACK_REPO_BASE_DIR/test-deployment-spec.yml
 $TEST_TARGET_SO init --deploy-to k8s-kind \
-  --stack $STACK_PATH \
+  --stack $STACK_NAME \
   --output $test_deployment_spec \
   --http-proxy-fqdn localhost \
   --config REACT_APP_API_URL=http://localhost/api/todos


### PR DESCRIPTION
Instead of `$repo_dir/$repo_name` it is `$repo_dir/$repo_host/$repo_org/$repo_name`

For example:

`~/.stack/repos/gitea.com/gitea/act_runner` instead of `~/.stack/repos/act_runner`