### PR TITLE
Improve container.lock handling

### DIFF
--- a/src/stack/build/build_containers.py
+++ b/src/stack/build/build_containers.py
@@ -1,8 +1,5 @@
 # Copyright © 2022, 2023 Vulcanize
 # Copyright © 2025 Bozeman Pass, Inc.
-import hashlib
-import sys
-import time
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as published by

--- a/src/stack/build/build_containers.py
+++ b/src/stack/build/build_containers.py
@@ -24,23 +24,19 @@ import git
 import os
 
 from pathlib import Path
-
 from python_on_whales import DockerClient
 
-from stack.config.util import get_config_setting, get_dev_root_path, debug_enabled
 from stack.base import get_npm_registry_url
 from stack.build.build_types import BuildContext
 from stack.build.build_util import ContainerSpec, get_containers_in_scope, container_exists_locally, container_exists_remotely, local_container_arch
 from stack.build.publish import publish_image
+from stack.config.util import get_config_setting, get_dev_root_path, debug_enabled
 from stack.constants import container_file_name, container_lock_file_name
 from stack.deploy.stack import get_parsed_stack_config, resolve_stack
-from stack.opts import opts
-from stack.repos.repo_util import host_and_path_for_repo, image_registry_for_repo, fs_path_for_repo, process_repo, \
-    get_repo_current_hash, is_repo_dirty, get_container_tag_for_repo
-from stack.util import include_exclude_check, stack_is_external, error_exit, get_yaml
-
 from stack.log import log_info, log_debug, log_warn, output_main
-
+from stack.opts import opts
+from stack.repos.repo_util import host_and_path_for_repo, image_registry_for_repo, fs_path_for_repo, process_repo, get_repo_current_hash, is_repo_dirty, get_container_tag_for_repo
+from stack.util import include_exclude_check, stack_is_external, error_exit, get_yaml
 from stack.util import run_shell_command
 
 docker = DockerClient()

--- a/src/stack/build/build_containers.py
+++ b/src/stack/build/build_containers.py
@@ -32,14 +32,14 @@ from stack.base import get_npm_registry_url
 from stack.build.build_types import BuildContext
 from stack.build.build_util import ContainerSpec, get_containers_in_scope, container_exists_locally, container_exists_remotely, local_container_arch
 from stack.build.publish import publish_image
-from stack.constants import container_file_name, container_lock_file_name, stack_file_name
-from stack.deploy.stack import Stack, get_parsed_stack_config, resolve_stack
+from stack.constants import container_file_name, container_lock_file_name
+from stack.deploy.stack import get_parsed_stack_config, resolve_stack
 from stack.opts import opts
 from stack.repos.repo_util import host_and_path_for_repo, image_registry_for_repo, fs_path_for_repo, process_repo, \
-    get_repo_current_hash, is_repo_dirty, hash_dirty_files, get_container_tag_for_repo
-from stack.util import include_exclude_check, stack_is_external, error_exit, get_yaml, check_if_stack_exists
+    get_repo_current_hash, is_repo_dirty, get_container_tag_for_repo
+from stack.util import include_exclude_check, stack_is_external, error_exit, get_yaml
 
-from stack.log import log_error, log_info, log_debug, log_warn, output_main, is_info_enabled
+from stack.log import log_info, log_debug, log_warn, output_main
 
 from stack.util import run_shell_command
 

--- a/src/stack/repos/repo_util.py
+++ b/src/stack/repos/repo_util.py
@@ -105,6 +105,21 @@ def hash_dirty_files(path):
     return m.hexdigest()
 
 
+def find_repo_root(path):
+    if isinstance(path, str):
+        path = Path(path)
+
+    ret = None
+    path = path.absolute()
+    while not ret and path and str(path.absolute().as_posix()) not in ["/"]:
+        if is_git_repo(path):
+            ret = path
+        else:
+            path = path.parent
+
+    return ret
+
+
 def get_container_tag_for_repo(path):
     tag = None
     git_hash = get_repo_current_hash(path)
@@ -112,7 +127,7 @@ def get_container_tag_for_repo(path):
         tag = git_hash
         if is_repo_dirty(path):
             dirty_hash = hash_dirty_files(path)
-            tag = "dirty-" + hashlib.sha1(f"{git_hash}:{dirty_hash}".encode()).hexdigest()
+            tag = "stackdev-" + hashlib.sha1(f"{git_hash}:{dirty_hash}".encode()).hexdigest()
     return tag
 
 

--- a/src/stack/repos/repo_util.py
+++ b/src/stack/repos/repo_util.py
@@ -15,22 +15,21 @@
 # along with this program.  If not, see <http:#www.gnu.org/licenses/>.
 
 import git
+import hashlib
 import os
+
+from git.exc import GitCommandError
+from pathlib import Path
+from tqdm import tqdm
 
 import stack.deploy.stack as stack_util
 
-from git.exc import GitCommandError
-from tqdm import tqdm
-from pathlib import Path
-
 from stack import constants
-from stack.config.util import get_dev_root_path
-from stack.opts import opts
-
 from stack.build import build_util
-from stack.util import include_exclude_check, error_exit
-
+from stack.config.util import get_dev_root_path
 from stack.log import log_debug, log_info, get_log_file, is_info_enabled, log_is_console
+from stack.opts import opts
+from stack.util import include_exclude_check, error_exit
 
 
 class GitProgress(git.RemoteProgress):
@@ -85,6 +84,36 @@ def get_repo_current_hash(path):
         return None
 
     return git.Repo(path).head.object.hexsha
+
+
+def is_repo_dirty(path):
+    if not is_git_repo(path):
+        return None
+
+    return git.Repo(path).is_dirty()
+
+
+def hash_dirty_files(path):
+    if not is_git_repo(path):
+        return None
+
+    if not is_repo_dirty(path):
+        return ""
+
+    m = hashlib.sha1()
+    m.update(git.Repo(path).git.diff().encode())
+    return m.hexdigest()
+
+
+def get_container_tag_for_repo(path):
+    tag = None
+    git_hash = get_repo_current_hash(path)
+    if git_hash:
+        tag = git_hash
+        if is_repo_dirty(path):
+            dirty_hash = hash_dirty_files(path)
+            tag = "dirty-" + hashlib.sha1(f"{git_hash}:{dirty_hash}".encode()).hexdigest()
+    return tag
 
 
 # See: https://stackoverflow.com/questions/18659425/get-git-current-branch-tag-name


### PR DESCRIPTION
Improve container.lock file creation and handling so we behave in a less surprising manner:

Now we:
```
# Only write the lock file if:
#   (1) the build succeeded
#   (2) there is a container.yml
#   (3) it references a git repo other than its own
```

So, if no container.yml is specified (for default builds) or it references its own repo (ie, it is in the same repo as the code being built) we do not write a lock file.  However, if it references an external repo, we do (see https://github.com/bozemanpass/gitea-containers/tree/main/act-runner for a good example).

We also now detect if the local repo is dirty, and alter the tag to be: f"stackdev-{sha1(git_hash + ':' + hash_of_git_diff)}"

This allows for much easier local development, avoiding unnecessary builds, but also not getting stuck on a past build.
