### PR TITLE
Docker should use the deployment name in the service image tag

### DIFF
--- a/src/stack/deploy/compose/deploy_docker.py
+++ b/src/stack/deploy/compose/deploy_docker.py
@@ -142,7 +142,6 @@ class DockerDeployerConfigGenerator(DeployerConfigGenerator):
         super().__init__()
         self.deployment_context = deployment_context
 
-    # Nothing needed at present for the docker deployer
     def generate(self, deployment_dir: Path):
         yaml = get_yaml()
         compose_files = self.deployment_context.get_compose_files()

--- a/src/stack/deploy/deployment_create.py
+++ b/src/stack/deploy/deployment_create.py
@@ -507,6 +507,10 @@ def create_operation(deployment_command_context, parsed_spec: Spec | MergedSpec,
             services = parsed_pod_file["services"]
             for service_name in services:
                 service_info = services[service_name]
+                image_name = service_info["image"]
+                if image_name.endswith(":stack"):
+                    service_info["image"] = image_name[:-5] + deployment_command_context.cluster_context.cluster
+
                 shared_cfg_file = os.path.join(
                     "../" * len(destination_compose_dir.relative_to(deployment_dir_path).parts), constants.config_file_name
                 )


### PR DESCRIPTION
```
image: bpi/siwe-express-example:bpi-a024316273cbc250
```

not

```
image: bpi/siwe-express-example:stack
```

To keep the docker case simpler than k8s, we will automatically tag foo:stack to foo:clusterid on first start up if (a) foo:clusterid does not exist locally, and (b) foo:stack does.