### PR TITLE
102: Change default path to ~/.config/stack

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,7 +26,7 @@ siwe-on-fixturenet
 Show paths and filter:
 ```
 $ stack list --show-path todo
-todo         /home/example/.stack/repos/github.com/bozemanpass/example-todo-list/stacks/todo
+todo         /home/example/.config/stack/repos/github.com/bozemanpass/example-todo-list/stacks/todo
 ```
 
 ## prepare the stack containers

--- a/docs/install.md
+++ b/docs/install.md
@@ -58,7 +58,7 @@ stack update
 
 If you want to update from a different location (e.g., a fork), you can do so setting the distribution URL to use:
 
-Save the alternate distribution URL in `~/.stack/config.yml`:
+Save the alternate distribution URL in `~/.config/stack/config.yml`:
 
 ```bash
 stack config set distribution-url https://github.com/example-org/my-stack-fork/releases/latest/download/stack

--- a/src/stack/build/build_containers.py
+++ b/src/stack/build/build_containers.py
@@ -17,7 +17,7 @@
 # Builds or pulls containers for the system components
 
 # env vars:
-# STACK_REPO_BASE_DIR defaults to ~/.stack/repos
+# STACK_REPO_BASE_DIR defaults to ~/.config/stack/repos
 
 import click
 import git

--- a/src/stack/build/build_webapp.py
+++ b/src/stack/build/build_webapp.py
@@ -17,7 +17,7 @@
 # Builds webapp containers
 
 # env vars:
-# STACK_REPO_BASE_DIR defaults to ~/.stack/repos
+# STACK_REPO_BASE_DIR defaults to ~/.config/stack/repos
 
 # TODO: display the available list of containers; allow re-build of either all or specific containers
 

--- a/src/stack/config/util.py
+++ b/src/stack/config/util.py
@@ -19,11 +19,11 @@ import stack.util
 from pathlib import Path
 
 
-_DEFAULTS = {"repo-base-dir": "~/.stack/repos"}
+_DEFAULTS = {"repo-base-dir": "~/.config/stack/repos"}
 
 
 def get_config_dir():
-    return Path(os.path.expanduser("~/.stack"))
+    return Path(os.path.expanduser("~/.config/stack"))
 
 
 def get_config_file_path():

--- a/src/stack/deploy/webapp/run_webapp.py
+++ b/src/stack/deploy/webapp/run_webapp.py
@@ -17,7 +17,7 @@
 # Builds webapp containers
 
 # env vars:
-# STACK_REPO_BASE_DIR defaults to ~/.stack/repos
+# STACK_REPO_BASE_DIR defaults to ~/.config/stack/repos
 
 # TODO: display the available list of containers; allow re-build of either all or specific containers
 

--- a/src/stack/repos/fetch_stack.py
+++ b/src/stack/repos/fetch_stack.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http:#www.gnu.org/licenses/>.
 
 # env vars:
-# STACK_REPO_BASE_DIR defaults to ~/.stack/repos
+# STACK_REPO_BASE_DIR defaults to ~/.config/stack/repos
 
 
 import click


### PR DESCRIPTION
```
❯ stack list --show-path
docker-ingress                /home/telackey/.config/stack/repos/github.com/bozemanpass/docker-ingress-stack/stacks/docker-ingress
docker-ingress-no-ssl         /home/telackey/.config/stack/repos/github.com/bozemanpass/docker-ingress-stack/stacks/docker-ingress-no-ssl
siwe-express-example          /home/telackey/.config/stack/repos/github.com/bozemanpass/siwe-express-example/stacks/siwe-express-example
siwe-on-fixturenet            /home/telackey/.config/stack/repos/github.com/bozemanpass/siwe-express-example/stacks/siwe-on-fixturenet
```