### PR TITLE
97: Better error messages on certain container.yml parsing problems.

### DIFF
--- a/src/stack/build/build_util.py
+++ b/src/stack/build/build_util.py
@@ -29,7 +29,8 @@ import stack.deploy.stack as stack_util
 
 from stack.log import log_debug
 from stack.repos.repo_util import find_repo_root
-from stack.util import warn_exit, get_yaml
+from stack.util import warn_exit, get_yaml, error_exit
+
 
 class StackContainer:
     name: str
@@ -77,7 +78,11 @@ class ContainerSpec:
         self.path = Path(self.file_path).parent.as_posix()
 
         y = get_yaml().load(open(file_path, "r"))
-        self.name = y["container"]["name"]
+        if "container" not in y:
+            error_exit(f"No 'container' section in {file_path}.")
+        self.name = y["container"].get("name", self.name)
+        if not self.name:
+            error_exit(f"Missing required property 'name' in 'container' section of {file_path}.")
         self.ref = y["container"].get("ref")
         self.build = y["container"].get("build")
         self.repo_path = find_repo_root(self.path)


### PR DESCRIPTION
```
~/bpi ❯ stack prepare --stack gitea
2025-08-06 17:47:22.567948: Found 2 containers in 1 stacks: bozemanpass/act-runner, bozemanpass/gitea
2025-08-06 17:47:22.570707: Preparing bozemanpass/act-runner (1 of 2)
2025-08-06 17:47:22.571539: ERROR: No 'container' section in /home/telackey/.config/stack/repos/github.com/bozemanpass/gitea-containers/./act-runner/container.yml.

~/bpi ❯ stack prepare --stack gitea
2025-08-06 17:52:02.435007: Found 2 containers in 1 stacks: bozemanpass/act-runner, bozemanpass/gitea
2025-08-06 17:52:02.437779: Preparing bozemanpass/act-runner (1 of 2)
2025-08-06 17:52:02.438548: ERROR: Missing required property 'name' in 'container' section of /home/telackey/.config/stack/repos/github.com/bozemanpass/gitea-containers/./act-runner/container.yml.
```