### PR TITLE
99: Improve --git-pull behavior

### DIFF
--- a/src/stack/build/build_containers.py
+++ b/src/stack/build/build_containers.py
@@ -290,14 +290,17 @@ def build_containers(parent_stack,
                                 else:
                                     target_hash = git_hash
                         else:
-                            if git_pull and target_fs_repo_path not in dont_pull_repo_fs_paths:
-                                process_repo(git_pull, False, git_ssh, dev_root_path, [], container_spec.ref)
-                                dont_pull_repo_fs_paths.append(target_fs_repo_path)
+                            if git_pull:
+                                if locked_hash:
+                                    log_warn(f"WARN: Locked hash {locked_hash} from {container_lock_file_path} prevents pulling.")
+                                elif not target_fs_repo_path not in dont_pull_repo_fs_paths:
+                                    process_repo(git_pull, False, git_ssh, dev_root_path, [], container_spec.ref)
+                                    dont_pull_repo_fs_paths.append(target_fs_repo_path)
                             git_hash = get_repo_current_hash(target_fs_repo_path)
                             if locked_hash:
                                 if locked_hash != git_hash:
                                     log_warn(
-                                        f"WARN: Locked hash {locked_hash} from {container_lock_file_path} does not match loacl hash {git_hash}."
+                                        f"WARN: Locked hash {locked_hash} from {container_lock_file_path} does not match local hash {git_hash}."
                                     )
                             else:
                                 target_hash = git_hash

--- a/src/stack/build/build_util.py
+++ b/src/stack/build/build_util.py
@@ -27,7 +27,7 @@ from python_on_whales import DockerClient
 
 import stack.deploy.stack as stack_util
 
-from stack.log import log_debug
+from stack.log import log_debug, log_info
 from stack.repos.repo_util import find_repo_root
 from stack.util import warn_exit, get_yaml, error_exit
 
@@ -125,9 +125,9 @@ def get_containers_in_scope(stack):
             stack_config = stack_util.get_parsed_stack_config(stack)
         else:
             stack_config = stack
-        if "containers" not in stack_config or stack_config["containers"] is None:
+        raw_containers = stack_config.get("containers", [])
+        if not raw_containers and not stack.is_super_stack():
             warn_exit(f"stack {stack} does not define any containers")
-        raw_containers = stack_config['containers']
     else:
         # See: https://stackoverflow.com/a/20885799/1701505
         from stack import data

--- a/src/stack/build/prepare.py
+++ b/src/stack/build/prepare.py
@@ -64,10 +64,10 @@ def command(
         error_exit(f"{build_policy} is not one of {PREPARE_POLICIES}")
 
     stack = resolve_stack(stack)
-    clone_all_repos_for_stack(stack, include_repos, exclude_repos, git_pull, git_ssh)
+    cloned_or_pulled_repos = clone_all_repos_for_stack(stack, include_repos, exclude_repos, git_pull, git_ssh)
 
     if build_policy == "fetch-repos":
         return
 
     build_containers(stack, build_policy, image_registry, publish_images, include_containers, exclude_containers,
-                     extra_build_args, git_ssh, target_arch, dont_pull_images)
+                     extra_build_args, git_ssh, git_pull, cloned_or_pulled_repos, target_arch, dont_pull_images)

--- a/src/stack/repos/repo_util.py
+++ b/src/stack/repos/repo_util.py
@@ -58,6 +58,7 @@ def host_and_path_for_repo(fully_qualified_repo):
         if len(repo_host_split) == 3:
             # First part is the host
             return repo_host_split[0], "/".join(repo_host_split[1:]), repo_branch
+    return None, None, None
 
 
 def image_registry_for_repo(repository):

--- a/src/stack/repos/repo_util.py
+++ b/src/stack/repos/repo_util.py
@@ -154,7 +154,9 @@ def _get_repo_current_branch_or_tag(full_filesystem_repo_path):
 
 def fs_path_for_repo(fully_qualified_repo, dev_root_path=get_dev_root_path()):
     repo_host, repo_path, repo_branch = host_and_path_for_repo(fully_qualified_repo)
-    return Path(os.path.join(dev_root_path, repo_host, repo_path))
+    if repo_host and repo_path:
+        return Path(os.path.join(dev_root_path, repo_host, repo_path))
+    return None
 
 
 # TODO: fix the messy arg list here


### PR DESCRIPTION
This improves the logic when using `prepare --git-pull` so that repos should not be skipped, the same repo should not be pulled more than once, and appropriate warnings are displayed when locked hashes involved.