### PR TITLE
Rework stack detection to avoid duplicates

### DIFF
--- a/src/stack/deploy/stack.py
+++ b/src/stack/deploy/stack.py
@@ -25,7 +25,7 @@ import stack.repos.repo_util as repo_util
 
 from stack import constants
 from stack.config.util import get_dev_root_path
-from stack.log import log_debug
+from stack.log import log_debug, log_warn
 from stack.util import get_yaml, get_stack_path, error_exit, resolve_compose_file, STACK_USE_BUILTIN_STACK
 
 
@@ -428,10 +428,24 @@ def pod_has_scripts(parsed_stack, pod_name: str):
     return result
 
 
+def _is_deployment_stack_copy(stack_file_path: Path, search_path: Path):
+    # A deployment directory contains a copy of the stack's files beside its
+    # deployment.yml; that copy belongs to the deployment, not to the set of
+    # stacks available to build or deploy from.
+    for ancestor in Path(stack_file_path).parents:
+        if ancestor.joinpath(constants.deployment_file_name).exists():
+            return True
+        if ancestor == search_path:
+            break
+    return False
+
+
 def locate_stacks_beneath(search_path=get_dev_root_path()):
     stacks = []
     if search_path.exists():
         for path in search_path.rglob("stack.yml"):
+            if _is_deployment_stack_copy(path, search_path):
+                continue
             stacks.append(Stack().init_from_file(path))
 
     return stacks
@@ -443,11 +457,13 @@ def locate_single_stack(stack_name, search_path=get_dev_root_path(), fail_on_mul
     if len(candidates) == 1:
         return candidates[0]
     elif len(candidates) > 1:
+        candidate_paths = ", ".join(str(s.file_path.parent) for s in candidates)
         if fail_on_multiple:
-            error_exit(f"multiple stacks named {stack_name} found")
+            error_exit(f"multiple stacks named {stack_name} found: {candidate_paths}")
         else:
-            # DBDB this means that if we asked to find a stack, found two or more stacks, and specified
-            # fail_on_multiple=False then it looks the same to the caller as if we found zero stacks.
+            # The caller treats this the same as finding no stack at all, so make the
+            # ambiguity visible rather than letting it surface as "stack not found".
+            log_warn(f"WARN: multiple stacks named {stack_name} found: {candidate_paths}")
             return None
 
     if fail_on_none:

--- a/tests/deploy/run-deploy-test.sh
+++ b/tests/deploy/run-deploy-test.sh
@@ -94,13 +94,14 @@ echo "Running stack deploy test"
 # Bit of a hack, test the most recent package
 TEST_TARGET_SO=$( ls -t1 ./package/stack* | head -1 )
 # Set a non-default repo dir
-export STACK_REPO_BASE_DIR=~/stack-test/repo-base-dir
+STACK_TEST_DIR=~/stack-test/deploy-test-dir
+export STACK_REPO_BASE_DIR=${STACK_TEST_DIR}/repo-base-dir
 echo "Testing this package: $TEST_TARGET_SO"
 echo "Test version command"
 reported_version_string=$( $TEST_TARGET_SO version )
 echo "Version reported is: ${reported_version_string}"
 echo "Cloning repositories into: $STACK_REPO_BASE_DIR"
-rm -rf $STACK_REPO_BASE_DIR
+rm -rf $STACK_TEST_DIR
 mkdir -p $STACK_REPO_BASE_DIR
 # Test bringing the test container up and down
 # with and without volume removal
@@ -111,8 +112,10 @@ $TEST_TARGET_SO fetch repo bozemanpass/example-todo-list
 $TEST_TARGET_SO prepare --stack $STACK_NAME
 
 # Basic test of creating a deployment
-test_deployment_dir=$STACK_REPO_BASE_DIR/test-deployment-dir
-test_deployment_spec=$STACK_REPO_BASE_DIR/test-deployment-spec.yml
+# Deployment artifacts live outside the repo base dir, so the deployment's copy
+# of the stack files is not seen when resolving stacks by name.
+test_deployment_dir=$STACK_TEST_DIR/test-deployment-dir
+test_deployment_spec=$STACK_TEST_DIR/test-deployment-spec.yml
 $TEST_TARGET_SO init --stack $STACK_NAME --output $test_deployment_spec --map-ports-to-host localhost-same
 # Check the file now exists
 if [ ! -f "$test_deployment_spec" ]; then

--- a/tests/k8s-deployment-control/run-test.sh
+++ b/tests/k8s-deployment-control/run-test.sh
@@ -59,19 +59,22 @@ delete_cluster_exit () {
 export STACK_USE_BUILTIN_STACK=true
 
 # Set a non-default repo dir
-export STACK_REPO_BASE_DIR=~/stack-test/repo-base-dir
+STACK_TEST_DIR=~/stack-test/k8s-deployment-control-test-dir
+export STACK_REPO_BASE_DIR=${STACK_TEST_DIR}/repo-base-dir
 echo "Testing this package: $TEST_TARGET_SO"
 echo "Test version command"
 reported_version_string=$( $TEST_TARGET_SO version )
 echo "Version reported is: ${reported_version_string}"
 echo "Cloning repositories into: $STACK_REPO_BASE_DIR"
-rm -rf $STACK_REPO_BASE_DIR
+rm -rf $STACK_TEST_DIR
 mkdir -p $STACK_REPO_BASE_DIR
 $TEST_TARGET_SO fetch repositories --stack test
 $TEST_TARGET_SO build containers --stack test
 # Test basic stack deploy to k8s
-test_deployment_dir=$STACK_REPO_BASE_DIR/test-deployment-dir
-test_deployment_spec=$STACK_REPO_BASE_DIR/test-deployment-spec.yml
+# Deployment artifacts live outside the repo base dir, so the deployment's copy
+# of the stack files is not seen when resolving stacks by name.
+test_deployment_dir=$STACK_TEST_DIR/test-deployment-dir
+test_deployment_spec=$STACK_TEST_DIR/test-deployment-spec.yml
 
 # Create a deployment that we can use to check our test cases
 $TEST_TARGET_SO --stack test deploy --deploy-to k8s-kind init --output $test_deployment_spec

--- a/tests/static-content-test/run-static-content-test.sh
+++ b/tests/static-content-test/run-static-content-test.sh
@@ -16,7 +16,8 @@ else
     TEST_TARGET_SO=$( ls -t1 ./package/stack* | head -1 )
 fi
 # Set a non-default repo dir
-export STACK_REPO_BASE_DIR=~/stack-test/static-content-repo-base-dir
+STACK_TEST_DIR=~/stack-test/static-content-test-dir
+export STACK_REPO_BASE_DIR=${STACK_TEST_DIR}/repo-base-dir
 # Overridable for local testing against an unpushed content repo
 TEST_CONTENT_REPO=${STACK_TEST_STATIC_CONTENT_REPO:-https://github.com/bozemanpass/stack-test-static-content.git}
 echo "Testing this package: $TEST_TARGET_SO"
@@ -24,7 +25,7 @@ echo "Test version command"
 reported_version_string=$( $TEST_TARGET_SO version )
 echo "Version reported is: ${reported_version_string}"
 echo "Cloning repositories into: $STACK_REPO_BASE_DIR"
-rm -rf $STACK_REPO_BASE_DIR
+rm -rf $STACK_TEST_DIR
 mkdir -p $STACK_REPO_BASE_DIR
 git clone $TEST_CONTENT_REPO $STACK_REPO_BASE_DIR/stack-test-static-content
 
@@ -147,8 +148,10 @@ fi
 
 $TEST_TARGET_SO prepare --stack test-static-content
 
-test_deployment_dir=$STACK_REPO_BASE_DIR/test-deployment-dir
-test_deployment_spec=$STACK_REPO_BASE_DIR/test-deployment-spec.yml
+# Deployment artifacts live outside the repo base dir, so the deployment's copy
+# of the stack files is not seen when resolving stacks by name.
+test_deployment_dir=$STACK_TEST_DIR/test-deployment-dir
+test_deployment_spec=$STACK_TEST_DIR/test-deployment-spec.yml
 
 $TEST_TARGET_SO init --stack test-static-content --output $test_deployment_spec --map-ports-to-host localhost-same
 if [ ! -f "$test_deployment_spec" ]; then
@@ -236,8 +239,6 @@ docker run -d --name stack-test-registry -p 5000:5000 registry:2
 # image removal below; it has served its purpose, so stop it now.
 $TEST_TARGET_SO manage --dir $test_deployment_dir stop --delete-volumes
 
-# The deployment dir under STACK_REPO_BASE_DIR contains a copy of the stack
-# files, making resolution by stack name ambiguous from here on: use the path.
 static_content_stack_dir=$STACK_REPO_BASE_DIR/github.com/bozemanpass/stack-test-stacks/stack-files/stacks/test-static-content-stack
 
 $TEST_TARGET_SO prepare --stack $static_content_stack_dir --publish-images --image-registry localhost:5000


### PR DESCRIPTION
Also re-works the remaining tests that store deployment dirs under repos root.