### PR TITLE
Fixes to facilitate building stacks from files in the local filesystem

### DIFF
--- a/docs/fetching-containers.md
+++ b/docs/fetching-containers.md
@@ -25,14 +25,37 @@ a repository and branch tells you where the corresponding image is and which tag
 the commit (and, via its committed lock files, to every source commit) that produced it.  Images built from uncommitted
 or unpinned inputs get a `stackdev-` tag and are never published.
 
+## How discovery works
+
+For each container, under a policy that allows prebuilt images, `stack prepare` proceeds in order:
+
+1. Compute the expected image version: the recipe repo's commit hash (or a `stackdev-` version when the
+   checkout is dirty or an input is unpinned — see
+   [stack-files.md](./stack-files.md#image-identity-and-lock-files)).
+2. If `<image-name>:<version>` exists locally, use it: it is re-tagged as `<image-name>:stack`, which is
+   the name deployments consume.
+3. Otherwise check the registries (below) for it — skipped entirely for `stackdev-` versions, which are
+   never published.  On a hit the image is pulled and re-tagged as `<image-name>:stack`; how the image was
+   originally built (wrapper or otherwise) is irrelevant, and none of the build machinery is engaged.
+4. Otherwise build locally.
+
+The image name must start with the registry namespace — the GitHub organization for ghcr, the workspace
+for Bitbucket — e.g. an image named `myorg/my-app` is looked for at `ghcr.io/myorg/my-app:<version>`.
+
 ## Registry auto-detection
 
-When checking for prebuilt images, the registry to search is determined per container: the registry given
-with `--image-registry` (if any) is tried first, then a registry inferred from the container's recipe repo —
-`ghcr.io` for repos hosted on `github.com`, otherwise the repo host itself.  So for github-hosted
-containers, prebuilt images are discovered at `ghcr.io/<image-name>:<recipe-repo-hash>` with no configuration at all.
-Note that auto-detection applies only to *pulling*: publishing with `--publish-images` always requires an
-explicit `--image-registry`.
+The registries checked in step 3 are, in order: the registry given with `--image-registry` (if any), then
+a registry inferred from the container's recipe repo — `ghcr.io` for repos on `github.com`, `crg.apkg.io`
+for repos on `bitbucket.org`, `registry.gitlab.com` for repos on `gitlab.com`, otherwise the repo host
+itself (correct for e.g. self-hosted Gitea).  So for github-hosted containers, prebuilt images are
+discovered at `ghcr.io/<image-name>:<recipe-repo-hash>` with no configuration at all, and correspondingly
+for the other known hosts.
+
+Auto-detection applies only to *pulling*: publishing with `--publish-images` always requires an explicit
+`--image-registry`.
+
+Some registries (Bitbucket's included, unlike ghcr) do not support anonymous pulls at all: `docker login`
+is required before either discovery or pulling can succeed.
 
 A remote image only counts as available if its manifest includes the local machine's architecture (or the
 `--target-arch` architecture, when given).  If no matching architecture is published the image is treated as

--- a/docs/stack-files.md
+++ b/docs/stack-files.md
@@ -273,6 +273,17 @@ is never published or matched remotely: committing the lock file is what stabili
 Lock files exist to make builds reproducible.  To move a pin to a newer version, delete the lock file (or the
 relevant entry) and rebuild to regenerate it.
 
+### Building from a local checkout
+
+When a stack is loaded from a filesystem path (rather than located by name under the repo base directory),
+containers whose source is the stack's own repository build directly from that checkout — the repo is not
+cloned again, and the image identity and the built content always come from the same tree.  This is what a
+CI job wants: the pipeline's checkout is the build source, with no second clone (which for a private
+repository would need its own credentials).  It also means local modifications in a developer checkout are
+what gets built — with tracked changes producing a `stackdev-` tagged image, since the checkout no longer
+matches any commit.  Repositories referenced by `ref` that are *not* the stack's own are always cloned
+beneath the repo base directory, at their pinned versions.
+
 ## container.lock
 
 The `container.lock` file lives beside a `container.yml` whose `ref` names a different source repository, and pins

--- a/src/stack/build/build_containers.py
+++ b/src/stack/build/build_containers.py
@@ -38,6 +38,7 @@ from stack.build.build_util import (
     read_container_locks,
     read_stack_locks,
     recipe_repo_version,
+    same_repo_ref,
     write_stack_locks,
 )
 from stack.build.publish import publish_image
@@ -272,9 +273,14 @@ def _resolve_wrapper_for_container(building_container, wrapper_pin: dict):
 def _source_repo_dir(building_container, stack):
     """The repo whose source this container is built from.
 
-    `ref` names it.  A container.yml that omits `ref` means "the repo this descriptor lives
-    in", which is what `repo_path` records.  Failing both, the stack's own repo."""
+    `ref` names it.  A ref naming the stack's own repo resolves to the tree the stack was
+    loaded from (possibly a checkout outside the dev root), keeping the built content and
+    the image identity in the same tree.  A container.yml that omits `ref` means "the repo
+    this descriptor lives in", which is what `repo_path` records.  Failing both, the
+    stack's own repo."""
     if building_container.ref:
+        if stack is not None and getattr(stack, "repo_path", None) and same_repo_ref(building_container.ref, stack.get_repo_ref()):
+            return stack.repo_path
         return fs_path_for_repo(building_container.ref)
     if building_container.repo_path:
         return building_container.repo_path
@@ -437,7 +443,9 @@ def build_containers(parent_stack,
             if (not stack_container.ref or stack_container.ref == ".") and stack.get_repo_ref():
                 stack_container.ref = stack.get_repo_ref()
 
-            if stack_container.ref:
+            if stack_container.ref and not (
+                stack.repo_is_local_checkout() and same_repo_ref(stack_container.ref, stack.get_repo_ref())
+            ):
                 fs_path_for_container_specs = fs_path_for_repo(stack_container.ref, dev_root_path)
                 if not os.path.exists(fs_path_for_container_specs) or (git_pull and fs_path_for_container_specs not in dont_pull_repo_fs_paths):
                     process_repo(git_pull, False, git_ssh, dev_root_path, [], stack_container.ref)
@@ -503,15 +511,21 @@ def build_containers(parent_stack,
                 payload_version = None
                 deviating_inputs = []
                 if identity.payload_ref:
-                    target_fs_repo_path = fs_path_for_repo(identity.payload_ref, dev_root_path)
-                    if not os.path.exists(target_fs_repo_path) or (git_pull and target_fs_repo_path not in dont_pull_repo_fs_paths):
-                        fetch_ref = identity.payload_ref
-                        if identity.payload_pin:
-                            fetch_ref = f"{identity.payload_ref.split('@')[0]}@{identity.payload_pin}"
-                        process_repo(git_pull, False, git_ssh, dev_root_path, [], fetch_ref)
-                        dont_pull_repo_fs_paths.append(target_fs_repo_path)
-                    else:
+                    if identity.payload_is_recipe:
+                        # Colocated: the recipe tree is the payload source; it is already
+                        # present and its state is already reflected in the identity.
+                        target_fs_repo_path = identity.recipe_fs_path
                         log_info(f"Building {container_spec.name} from {target_fs_repo_path}")
+                    else:
+                        target_fs_repo_path = fs_path_for_repo(identity.payload_ref, dev_root_path)
+                        if not os.path.exists(target_fs_repo_path) or (git_pull and target_fs_repo_path not in dont_pull_repo_fs_paths):
+                            fetch_ref = identity.payload_ref
+                            if identity.payload_pin:
+                                fetch_ref = f"{identity.payload_ref.split('@')[0]}@{identity.payload_pin}"
+                            process_repo(git_pull, False, git_ssh, dev_root_path, [], fetch_ref)
+                            dont_pull_repo_fs_paths.append(target_fs_repo_path)
+                        else:
+                            log_info(f"Building {container_spec.name} from {target_fs_repo_path}")
                     payload_version = get_container_tag_for_repo(target_fs_repo_path)
                     if not identity.payload_is_recipe:
                         if not identity.payload_pin:

--- a/src/stack/build/build_util.py
+++ b/src/stack/build/build_util.py
@@ -230,7 +230,7 @@ def recipe_repo_version(recipe_fs_path, lock_file_path=None):
     return version
 
 
-def _same_repo(ref_a, ref_b):
+def same_repo_ref(ref_a, ref_b):
     if not ref_a or not ref_b:
         return False
     return ref_a.split("@")[0] == ref_b.split("@")[0]
@@ -321,7 +321,13 @@ def compute_image_identity(stack, stack_container, dev_root_path) -> ImageIdenti
 
     spec_dir = None
     if stack_container.ref:
-        fs_path_for_container_specs = Path(fs_path_for_repo(stack_container.ref, dev_root_path))
+        # A ref naming the stack's own repo resolves to the tree the stack was actually
+        # loaded from (which may be a checkout outside the dev root), so that identity
+        # and content always come from the same tree.
+        if stack and stack.repo_path and same_repo_ref(stack_container.ref, stack.get_repo_ref()):
+            fs_path_for_container_specs = Path(stack.repo_path)
+        else:
+            fs_path_for_container_specs = Path(fs_path_for_repo(stack_container.ref, dev_root_path))
         candidate_dir = fs_path_for_container_specs
         if stack_container.path:
             candidate_dir = candidate_dir.joinpath(stack_container.path)
@@ -365,7 +371,7 @@ def compute_image_identity(stack, stack_container, dev_root_path) -> ImageIdenti
     ident.container_spec = container_spec
     ident.payload_ref = container_spec.ref
     ident.wrapper_name = container_spec.wrapper
-    ident.payload_is_recipe = _same_repo(ident.payload_ref, ident.recipe_ref)
+    ident.payload_is_recipe = same_repo_ref(ident.payload_ref, ident.recipe_ref)
     embedded_payload_pin = _embedded_pin(ident.payload_ref)
     if not ident.payload_pin:
         ident.payload_pin = embedded_payload_pin

--- a/src/stack/checklist/checklist.py
+++ b/src/stack/checklist/checklist.py
@@ -23,6 +23,7 @@ from stack.build.build_util import (
     container_exists_locally,
     container_exists_remotely,
     local_container_arch,
+    same_repo_ref,
 )
 from stack.config.util import get_config_setting
 from stack.config.util import get_dev_root_path
@@ -53,7 +54,9 @@ def container_disposition(parent_stack, image_registry, git_ssh):
             if (not stack_container.ref or stack_container.ref == ".") and stack.get_repo_ref():
                 stack_container.ref = stack.get_repo_ref()
 
-            if stack_container.ref:
+            # A ref naming the stack's own repo resolves to the tree the stack was loaded
+            # from, which is present by definition; only other refs can be missing.
+            if stack_container.ref and not (stack.repo_path and same_repo_ref(stack_container.ref, stack.get_repo_ref())):
                 container_repo_fs_path = fs_path_for_repo(stack_container.ref, get_dev_root_path())
                 if not os.path.exists(container_repo_fs_path):
                     log_debug(f"Missing ref {stack_container.ref} needed by {stack_container.name}.")

--- a/src/stack/deploy/stack.py
+++ b/src/stack/deploy/stack.py
@@ -128,6 +128,21 @@ class Stack:
             return repo.remotes[0].url
         return None
 
+    def repo_is_local_checkout(self):
+        """True when this stack was loaded from a checkout other than the dev-root clone
+        of its repo -- a developer tree or a CI checkout.  Colocated containers of such a
+        stack build directly from that checkout, and its repo is never cloned."""
+        if not self._determine_repo_path():
+            return False
+        ref = self.get_repo_ref()
+        if not ref:
+            # No derivable repo ref (e.g. no usable remote): the checkout is all there is.
+            return True
+        dev_clone_path = repo_util.fs_path_for_repo(ref, get_dev_root_path())
+        if not dev_clone_path:
+            return True
+        return Path(self.repo_path).resolve() != Path(dev_clone_path).resolve()
+
     def get_required_stacks(self):
         return self.get(constants.requires_key, {}).get(constants.stacks_key)
 

--- a/src/stack/repos/repo_util.py
+++ b/src/stack/repos/repo_util.py
@@ -61,12 +61,20 @@ def host_and_path_for_repo(fully_qualified_repo):
     return None, None, None
 
 
+# The container registry associated with each known git hosting service.  Repos on
+# hosts not listed here (e.g. self-hosted Gitea/Forgejo, which serve a registry on
+# the git host itself) map to the host unchanged.
+KNOWN_HOST_IMAGE_REGISTRIES = {
+    "github.com": "ghcr.io",
+    "bitbucket.org": "crg.apkg.io",
+    "gitlab.com": "registry.gitlab.com",
+}
+
+
 def image_registry_for_repo(repository):
     host, path, _ = host_and_path_for_repo(repository)
-    if "github.com" == host:
-        return "ghcr.io"
-    elif host:
-        return host
+    if host:
+        return KNOWN_HOST_IMAGE_REGISTRIES.get(host, host)
     return None
 
 
@@ -275,7 +283,11 @@ def clone_all_repos_for_stack(stack, include=None, exclude=None, pull=False, git
             log_debug("Dev root directory doesn't exist, creating")
             os.makedirs(dev_root_path)
 
-        repos_in_scope = [req_stack.get_repo_ref()]
+        # A stack loaded from a local checkout builds its colocated containers from that
+        # checkout: its own repo is not cloned (it may not even be reachable, e.g. a
+        # private repo in CI).
+        stack_repo_is_local_checkout = req_stack.repo_is_local_checkout()
+        repos_in_scope = [] if stack_repo_is_local_checkout else [req_stack.get_repo_ref()]
         stack_repos = req_stack.get("repos", [])
         if stack_repos is not None:
             repos_in_scope.extend(req_stack.get("repos", []))
@@ -284,6 +296,8 @@ def clone_all_repos_for_stack(stack, include=None, exclude=None, pull=False, git
         containers_in_scope = build_util.get_containers_in_scope(req_stack)
         for c in containers_in_scope:
             if c.ref and c.ref != "." and c.ref not in repos_in_scope:
+                if stack_repo_is_local_checkout and build_util.same_repo_ref(c.ref, req_stack.get_repo_ref()):
+                    continue
                 repos_in_scope.append(c.ref)
 
         log_debug(f"Repos: {repos_in_scope}")


### PR DESCRIPTION
This worked in the past but had rotted in various places. Resurrecting to support CI scenarios where the stack definition is in the same repo as the CI job.