### PR TITLE
Add unit tests suite

### DIFF
--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -1,0 +1,25 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    name: "Run unit tests"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: "Clone project repository"
+        uses: actions/checkout@v5
+      - name: "Install uv"
+        uses: astral-sh/setup-uv@v8.2.0
+        with:
+          python-version: '3.12'
+      - name: "Install dependencies"
+        run: uv sync
+      - name: "Run pytest"
+        run: uv run pytest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,13 @@ Formatting uses `black` (available via `uv run black`). Linting config is in `to
 
 ## Testing
 
-Tests are **bash shell scripts**, not pytest. They require Docker and/or Kubernetes (Kind) to be available.
+Unit tests (pytest) live in `tests/unit/` and run the CLI in a subprocess with an isolated `HOME`, no Docker or Kubernetes required:
+
+```bash
+uv run pytest
+```
+
+The integration tests are **bash shell scripts**, not pytest. They require Docker and/or Kubernetes (Kind) to be available.
 
 ```bash
 # Smoke tests (basic CLI functionality)
@@ -120,4 +126,4 @@ Stacks can also provide custom subcommands loaded dynamically.
 
 - Build backend: `uv_build`
 - CI runs on GitHub Actions (see `.github/workflows/`)
-- Workflows: `lint.yml`, `test.yml`, `test-deploy.yml`, `test-deploy-k8s.yml`, `test-database.yml`, `test-webapp.yml`, `publish.yml`
+- Workflows: `lint.yml`, `test-unit.yml`, `test.yml`, `test-deploy.yml`, `test-deploy-k8s.yml`, `test-database.yml`, `test-webapp.yml`, `publish.yml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,10 @@ requires-python = ">=3.10"
 stack = "stack:main.cli"
 
 [dependency-groups]
-dev = ["flake8", "black"]
+dev = ["flake8", "black", "pytest"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests/unit"]
 
 [project.urls]
 "Homepage" = "https://github.com/bozemanpass/stack"

--- a/src/stack/__main__.py
+++ b/src/stack/__main__.py
@@ -1,0 +1,19 @@
+# Copyright © 2026 Bozeman Pass, Inc.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http:#www.gnu.org/licenses/>.
+
+from stack.main import cli
+
+if __name__ == "__main__":
+    cli()

--- a/src/stack/init/init.py
+++ b/src/stack/init/init.py
@@ -42,14 +42,21 @@ def _parse_http_proxy(raw_val: str):
     return {"service": service, "port": port, "path": path}
 
 
-def _output_checks(specs, deploy_to):
+def _output_checks(specs, deploy_to, http_proxy_fqdn_specified=False):
     merged = MergedSpec()
     for spec in specs:
         merged.merge(spec)
 
     if deploy_to in [constants.k8s_kind_deploy_type, constants.k8s_deploy_type]:
         if not merged.get_http_proxy():
-            log_info("NOTE: No HTTP proxy settings specified, external HTTP access will not be configured.")
+            if http_proxy_fqdn_specified:
+                log_warn(
+                    "WARN: --http-proxy-fqdn was specified but there are no HTTP proxy targets, so external "
+                    "HTTP access will not be configured. Specify --http-proxy-target, or use a stack which "
+                    "annotates a service port with http-proxy."
+                )
+            else:
+                log_info("NOTE: No HTTP proxy settings specified, external HTTP access will not be configured.")
         else:
             known_targets = set()
             for svc, ports in merged.get_network_ports().items():
@@ -154,6 +161,7 @@ def command(
         else:
             error_exit(f"Invalid config variable: {c}")
 
+    http_proxy_fqdn_specified = http_proxy_fqdn is not None
     if not http_proxy_fqdn:
         if deploy_to == "compose":
             http_proxy_fqdn = "localhost"
@@ -214,7 +222,7 @@ def command(
         )
         specs.append(spec)
 
-    _output_checks(specs, deploy_to)
+    _output_checks(specs, deploy_to, http_proxy_fqdn_specified)
 
     if len(specs) == 1:
         specs[0].dump(output)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,90 @@
+# Copyright © 2026 Bozeman Pass, Inc.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http:#www.gnu.org/licenses/>.
+
+import os
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+@pytest.fixture
+def isolated_env(tmp_path):
+    """Environment for running the CLI isolated from the developer's real
+    stack config (~/.config/stack) and any STACK_* environment settings."""
+    home = tmp_path / "home"
+    home.mkdir()
+    env = {k: v for k, v in os.environ.items() if not k.startswith("STACK_")}
+    env["HOME"] = str(home)
+    return env
+
+
+def run_stack(args, env, cwd=None):
+    """Run the stack CLI in a subprocess, returning CompletedProcess.
+
+    A subprocess (rather than click's CliRunner) is required because some CLI
+    option defaults read the config profile at module import time.
+    """
+    return subprocess.run(
+        [sys.executable, "-m", "stack"] + args,
+        env=env,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+
+
+def make_stack_fixture(base_dir, name="teststack", ports_yaml='      - "80"\n'):
+    """Create a minimal single-pod stack in a local git checkout and return its path.
+
+    The directory must look like a git clone with a remote so that stack.yml
+    resolution and pod-file lookup work.
+    """
+    stack_dir = base_dir / name
+    pod_dir = stack_dir / "web"
+    pod_dir.mkdir(parents=True)
+    (stack_dir / "stack.yml").write_text(
+        textwrap.dedent(
+            f"""\
+            name: {name}
+            description: "minimal test stack"
+            pods:
+              - name: web
+                path: ./web
+            """
+        )
+    )
+    (pod_dir / "composefile.yml").write_text(
+        "services:\n" "  web:\n" "    image: nginx:latest\n" "    ports:\n" + ports_yaml
+    )
+    subprocess.run(["git", "init", "-q", str(stack_dir)], check=True)
+    subprocess.run(
+        ["git", "-C", str(stack_dir), "remote", "add", "origin", f"https://github.com/example/{name}.git"],
+        check=True,
+    )
+    return stack_dir
+
+
+@pytest.fixture
+def minimal_stack(tmp_path):
+    """A stack whose service exposes a port with no http-proxy annotation."""
+    return make_stack_fixture(tmp_path)
+
+
+@pytest.fixture
+def annotated_stack(tmp_path):
+    """A stack whose service port carries an http-proxy annotation."""
+    return make_stack_fixture(tmp_path, name="annotatedstack", ports_yaml='      - "80"  # @stack http-proxy /\n')

--- a/tests/unit/test_init_http_proxy.py
+++ b/tests/unit/test_init_http_proxy.py
@@ -1,0 +1,92 @@
+# Copyright © 2026 Bozeman Pass, Inc.
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http:#www.gnu.org/licenses/>.
+
+import yaml
+
+from conftest import run_stack
+
+FQDN = "website-stage.example.com"
+
+FQDN_UNUSED_WARNING = "--http-proxy-fqdn was specified but there are no HTTP proxy targets"
+NO_PROXY_NOTE = "No HTTP proxy settings specified"
+
+
+def init_k8s(stack_dir, output_file, env, extra_args=None):
+    args = [
+        "init",
+        "--stack",
+        str(stack_dir),
+        "--deploy-to",
+        "k8s",
+        "--kube-config",
+        "placeholder",
+        "--output",
+        str(output_file),
+    ]
+    return run_stack(args + (extra_args or []), env)
+
+
+def test_fqdn_without_targets_warns(minimal_stack, tmp_path, isolated_env):
+    result = init_k8s(minimal_stack, tmp_path / "spec.yml", isolated_env, ["--http-proxy-fqdn", FQDN])
+    assert result.returncode == 0, result.stderr
+    output = result.stdout + result.stderr
+    assert FQDN_UNUSED_WARNING in output
+    assert NO_PROXY_NOTE not in output
+
+
+def test_no_proxy_settings_notes(minimal_stack, tmp_path, isolated_env):
+    result = init_k8s(minimal_stack, tmp_path / "spec.yml", isolated_env)
+    assert result.returncode == 0, result.stderr
+    output = result.stdout + result.stderr
+    assert NO_PROXY_NOTE in output
+    assert FQDN_UNUSED_WARNING not in output
+
+
+def test_fqdn_with_explicit_target(minimal_stack, tmp_path, isolated_env):
+    spec_file = tmp_path / "spec.yml"
+    result = init_k8s(
+        minimal_stack,
+        spec_file,
+        isolated_env,
+        ["--http-proxy-fqdn", FQDN, "--http-proxy-target", "web:80"],
+    )
+    assert result.returncode == 0, result.stderr
+    output = result.stdout + result.stderr
+    assert FQDN_UNUSED_WARNING not in output
+    assert NO_PROXY_NOTE not in output
+
+    spec = yaml.safe_load(spec_file.read_text())
+    proxies = spec["network"]["http-proxy"]
+    assert proxies == [
+        {
+            "host-name": FQDN,
+            "routes": [{"path": "/", "proxy-to": "web:80"}],
+            "cluster-issuer": "letsencrypt-prod",
+        }
+    ]
+
+
+def test_fqdn_with_annotated_port(annotated_stack, tmp_path, isolated_env):
+    spec_file = tmp_path / "spec.yml"
+    result = init_k8s(annotated_stack, spec_file, isolated_env, ["--http-proxy-fqdn", FQDN])
+    assert result.returncode == 0, result.stderr
+    output = result.stdout + result.stderr
+    assert FQDN_UNUSED_WARNING not in output
+    assert NO_PROXY_NOTE not in output
+
+    spec = yaml.safe_load(spec_file.read_text())
+    proxies = spec["network"]["http-proxy"]
+    assert proxies[0]["host-name"] == FQDN
+    assert proxies[0]["routes"] == [{"path": "/", "proxy-to": "web:80"}]

--- a/uv.lock
+++ b/uv.lock
@@ -184,6 +184,18 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "expandvars"
 version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -249,6 +261,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -365,6 +386,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pycodestyle"
 version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -435,6 +465,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]
@@ -693,6 +741,7 @@ dependencies = [
 dev = [
     { name = "black" },
     { name = "flake8" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
@@ -719,6 +768,7 @@ requires-dist = [
 dev = [
     { name = "black" },
     { name = "flake8" },
+    { name = "pytest" },
 ]
 
 [[package]]


### PR DESCRIPTION
This work began as a simple exercise to improve the error message printed when an http proxy configuration is supplied but there is no proxy target in the stack. Having fixed that issue, it expanded into a PR that adds a new unit test suite to the project, including a test covering that error message code.