### PR TITLE
Support pre-built images in k8s deployments

### DIFF
--- a/docs/image-names.md
+++ b/docs/image-names.md
@@ -1,0 +1,181 @@
+# Container Image Names and Tags
+
+This document describes, in one place, every scheme stack uses for container
+image names and tags, and the lifecycle of an image name from the stack
+definition through build, publish, and deployment. Related documents:
+[stack-files.md](stack-files.md) (where names are declared),
+[fetching-containers.md](fetching-containers.md) (how prebuilt images are
+discovered and pulled).
+
+## Design goals
+
+Two separations of concern drive the naming schemes:
+
+1. **Structure vs. versions.** A stack or pod file describes the *shape* of a
+   system — which containers exist and how they connect — and should not need
+   to embed exact image versions. Pod files therefore name images with a
+   placeholder tag, and the tooling substitutes a real version at the
+   appropriate time.
+
+2. **Source ↔ image binding.** An image is fully determined by the git
+   repository (and commit) holding its build recipe. Both the fully-qualified
+   image name and the tag are *derived* from the repository reference, so
+   given a repo ref, stack can compute where the corresponding image lives
+   without any extra configuration — and vice versa.
+
+## The three name forms
+
+An image for a container named `exampleorg/myapp` appears in three forms over
+its life:
+
+| Form | Example | Where it appears |
+|---|---|---|
+| Local placeholder | `exampleorg/myapp:stack` (legacy alias `:local`) | pod/compose files, local docker daemon after build or prepare |
+| Canonical (publishable) | `ghcr.io/exampleorg/myapp:<recipe-commit-hash>` | remote registries; produced by `--publish-images`, consumed by `prepare` |
+| Deployment-private | `<image-registry>/exampleorg/myapp:deploy-<id>` (k8s) or `exampleorg/myapp:stack-<cluster>` (compose) | generated deployment artifacts |
+
+### The container name
+
+The container `name:` declared in `stack.yml` / `container.yml` is the base
+image name. It must include the registry namespace under which the image is
+published (for GitHub/ghcr, the GitHub organization) — e.g.
+`exampleorg/myapp`, not just `myapp`. The canonical form is produced by
+prefixing the registry host, never by rewriting the name itself.
+
+### The placeholder tag `stack`
+
+`<name>:stack` means "the image for this container, as built or prepared on
+this machine." It is what pod files reference (`image: exampleorg/myapp:stack`)
+and it is only meaningful to the local docker daemon: every build or pull path
+ends by tagging its result as `<name>:stack` (and the legacy `<name>:local`).
+It is never pushed and never resolvable from a registry; any process that
+needs to pull must first translate it to one of the other two forms.
+
+## Canonical names: derived from the recipe repo
+
+### Registry from the git host
+
+`image_registry_for_repo()` (`src/stack/repos/repo_util.py`) maps the recipe
+repository's git host to its image registry:
+
+| Git host | Image registry |
+|---|---|
+| `github.com` | `ghcr.io` |
+| `gitlab.com` | `registry.gitlab.com` |
+| `bitbucket.org` | `crg.apkg.io` |
+| anything else | the host itself |
+
+### Tag from the commit hash
+
+The tag is the commit hash of the **recipe repo** — the repository holding
+the container build recipe (see `ImageIdentity` in
+`src/stack/build/build_util.py`). Lock files committed in the recipe repo pin
+all other build inputs (payload source, wrapper), so the recipe commit alone
+identifies the image content.
+
+If the recipe checkout is dirty, or the build used unpinned/deviating inputs,
+the version becomes `stackdev-<sha1 of the actual inputs>` instead. `stackdev-`
+versions are never published — they identify a local development build only.
+
+So the full canonical reference is:
+
+```
+<registry-for-git-host>/<container name>:<recipe repo commit hash>
+e.g.  ghcr.io/exampleorg/myapp:0badc0ffee...
+```
+
+Given only the stack definition (which carries the repo refs), stack can
+compute this reference — this is what lets `prepare` find prebuilt images
+with no configuration.
+
+## Lifecycle of an image name
+
+### 1. Authoring
+
+`stack.yml`/`container.yml` declare `name: exampleorg/myapp`; the pod compose
+file references `image: exampleorg/myapp:stack`.
+
+### 2. `stack prepare` / `stack build containers`
+
+For each container in scope (`src/stack/build/build_containers.py`):
+
+1. Compute the `ImageIdentity` → expected tag `exampleorg/myapp:<hash>`.
+2. If that tag exists locally, use it.
+3. Otherwise (per the build policy) look for it remotely, checking in order:
+   the `--image-registry` override, then the canonical registry derived from
+   the recipe repo. If found, `docker pull <registry>/exampleorg/myapp:<hash>`.
+4. Otherwise build it.
+5. In every case, cross-tag the result so that `exampleorg/myapp:<hash>`,
+   `exampleorg/myapp:stack`, and `exampleorg/myapp:local` all point at the
+   same image locally.
+
+With `--publish-images`, the image is additionally pushed as
+`<registry>/exampleorg/myapp:<hash>` (refused for `stackdev-` versions).
+
+### 3. `stack init`
+
+Generates the deployment spec. For k8s targets only, `--image-registry <url>`
+is recorded in the spec (`image-registry:` key). This designates a *private
+staging registry* used to carry locally-built images to the cluster; it is
+unrelated to the canonical registry derivation above. If omitted for a `k8s`
+target, locally-built images are deployable only if they are published to a
+registry the cluster can reach (see step 5), and `init` warns accordingly.
+
+### 4. `stack deploy create`
+
+- **compose target:** each `image: <name>:stack` in the generated compose
+  files is rewritten to `<name>:stack-<cluster-id>` so that concurrent
+  deployments on one host don't share a mutable tag. At `up` time the local
+  `<name>:stack` image is retagged to match (erroring with "did you run
+  stack prepare?" if absent).
+- **k8s targets:** pod files keep `<name>:stack`; translation happens at
+  manifest-generation time (next step).
+
+### 5. k8s deployment (`cluster_info.py` + `images.py`)
+
+At manifest-generation time, each image reference is resolved per image
+(`resolve_image_for_deployment`):
+
+1. **Not a locally-built tag** (e.g. an explicit upstream image like
+   `postgres:16`): passed through untouched, pulled exactly as the pod file
+   names it.
+2. **Locally-built tag (`:stack`/`:local`), staging registry configured**:
+   rewritten to the deployment-private staging name
+
+   ```
+   exampleorg/myapp:stack  →  <image-registry>/exampleorg/myapp:deploy-<last 8 of deployment id>
+   ```
+
+   (registry host replaced, org namespace kept). `stack manage --dir <dir>
+   push-images` performs the matching upload: it tags every locally-built
+   image with exactly that name and pushes it to the staging registry.
+3. **Locally-built tag, no staging registry**: the published canonical
+   reference is used. `prepare` and `--publish-images` leave the answer in
+   the local docker daemon's tags — a pulled or published image carries
+   `ghcr.io/exampleorg/myapp:<hash>` alongside the `exampleorg/myapp:<hash>`
+   and `:stack` cross-tags — so the resolver inspects the local image and
+   uses the registry-qualified sibling tag whose version matches. The
+   cluster then pulls directly from the canonical registry.
+4. **Neither available** (built locally, unpublished, no staging registry):
+   the deployment cannot work, so manifest generation fails immediately with
+   the remedy, instead of the cluster reporting `ImagePullBackOff` later.
+
+Exception: a **kind** deployment with no staging registry loads local images
+directly into the kind cluster, so the local reference is used as-is.
+
+The generated pod specs reference an image pull secret named
+`stack-image-registry`. Stack assumes registry credentials (for the staging
+registry and/or the canonical registries) are configured on the target
+cluster out of band, at cluster-configuration time.
+
+## Known gaps
+
+- Only one pull secret name (`stack-image-registry`) is referenced, and it is
+  referenced unconditionally — deployments that pull only from public
+  registries see a harmless but noisy `FailedToRetrieveImagePullSecret`
+  warning on every pod.
+- When an image is both published canonically and staged, the staging
+  registry wins; there is no per-deployment switch to prefer the canonical
+  reference while still configuring a staging registry for other images.
+- Deployment-private staging tags (`deploy-<id>`) accumulate in the staging
+  registry; nothing cleans them up when a deployment is destroyed.

--- a/src/stack/deploy/deployment_create.py
+++ b/src/stack/deploy/deployment_create.py
@@ -283,7 +283,10 @@ def init_operation(  # noqa: C901
         if image_registry:
             spec_file_content.update({constants.image_registry_key: image_registry})
         elif deployer_type == "k8s":
-            log_warn("WARN: --image-registry not specified, only default container registries (eg, Docker Hub) will be available")
+            log_warn(
+                "WARN: --image-registry not specified: locally built images can only be deployed"
+                " if they are published to a container registry the cluster can reach"
+            )
         if http_proxy_targets:
             routes = []
             for target in http_proxy_targets:

--- a/src/stack/deploy/images.py
+++ b/src/stack/deploy/images.py
@@ -23,6 +23,7 @@ from stack.deploy.deployment_context import DeploymentContext
 from stack.deploy.deploy_types import DeployCommandContext
 from stack.deploy.deploy_util import images_for_deployment
 from stack.log import log_debug
+from stack.util import error_exit
 
 
 # The tags stack builds locally.  Only these are redirected at a deployment's registry;
@@ -30,12 +31,26 @@ from stack.log import log_debug
 LOCALLY_BUILT_TAGS = ("local", "stack")
 
 
-def _split_image_reference(image: str):
-    """Split an image reference into its bare name and its tag.
+def _strip_registry_host(image_name: str):
+    """Drop a leading registry host (`ghcr.io/`, `localhost:5000/`) from an image name.
 
-    The name is the last path component: any host and org in the reference are dropped,
-    because the remote registry URL replacing them carries its own.  So both
-    `bar:stack` and `foo.io/org/bar:stack` yield ("bar", "stack").
+    Follows the standard reference heuristic: the first path component is a host only
+    if it contains a '.' or ':' or is exactly "localhost"; otherwise it is an org
+    (`someorg/bar` has no host).
+    """
+    first_component, sep, rest = image_name.partition("/")
+    if sep and ("." in first_component or ":" in first_component or first_component == "localhost"):
+        return rest
+    return image_name
+
+
+def _split_image_reference(image: str):
+    """Split an image reference into its host-less name and its tag.
+
+    Any registry host in the reference is dropped, because the remote registry URL
+    replacing it carries its own, but the org path is kept -- it is part of the image's
+    identity and registries like ghcr require a namespace.  So `org/bar:stack` and
+    `foo.io/org/bar:stack` both yield ("org/bar", "stack").
 
     A ':' only introduces a tag when it follows the last '/' -- a registry host may
     carry a port, as in `localhost:5000/bar`.  The tag is None when there is none,
@@ -44,10 +59,11 @@ def _split_image_reference(image: str):
     """
     last_path_component = image.rsplit("/", 1)[-1]
     if ":" in last_path_component:
-        image_name, image_version = last_path_component.rsplit(":", 1)
+        image_version = last_path_component.rsplit(":", 1)[1]
+        image_name = image[: len(image) - len(image_version) - 1]
     else:
-        image_name, image_version = last_path_component, None
-    return image_name, image_version
+        image_name, image_version = image, None
+    return _strip_registry_host(image_name), image_version
 
 
 def _image_needs_pushed(image: str):
@@ -58,7 +74,7 @@ def _image_needs_pushed(image: str):
 
 
 def _remote_tag_for_image(image: str, remote_repo_url: str):
-    # Turns image tags of the form: foo/bar:stack into remote.repo/org/bar:deploy
+    # Turns image tags of the form: org/bar:stack into remote.repo/org/bar:deploy
     image_name, image_version = _split_image_reference(image)
     if image_version in LOCALLY_BUILT_TAGS:
         return f"{remote_repo_url}/{image_name}:deploy"
@@ -92,7 +108,7 @@ def add_tags_to_image(remote_repo_url: str, local_tag: str, *additional_tags):
 
 
 def remote_tag_for_image_unique(image: str, remote_repo_url: str, deployment_id: str):
-    # Turns image tags of the form: foo/bar:stack into remote.repo/org/bar:deploy
+    # Turns image tags of the form: org/bar:stack into remote.repo/org/bar:deploy-<id>
     image_name, image_version = _split_image_reference(image)
     if image_version in LOCALLY_BUILT_TAGS:
         # Salt the tag with part of the deployment id to make it unique to this deployment
@@ -102,13 +118,84 @@ def remote_tag_for_image_unique(image: str, remote_repo_url: str, deployment_id:
         return image
 
 
+def _published_reference_for_image(image: str):
+    """Find the registry-qualified reference under which a locally built image is published.
+
+    `stack prepare` leaves the answer in the local daemon's tags: pulling a prebuilt
+    image records `ghcr.io/org/bar:<hash>` alongside the `org/bar:<hash>` and
+    `org/bar:stack` cross-tags, and `--publish-images` tags what it pushes the same
+    way.  So a sibling tag that carries a registry host, and whose name and version
+    match an unqualified sibling, is a reference the cluster can pull directly.
+
+    Requiring the version to also exist as an unqualified tag keeps deployment-private
+    staging tags (`reg/org/bar:deploy-xxxx`, which have no unqualified counterpart)
+    from being mistaken for a published image.
+
+    Returns None when the image has no such tag -- or does not exist locally at all.
+    """
+    image_name, _ = _split_image_reference(image)
+    try:
+        repo_tags = DockerClient().image.inspect(image).repo_tags
+    except Exception:
+        return None
+
+    local_versions = set()
+    qualified = []
+    for ref in repo_tags:
+        ref_name, ref_version = _split_image_reference(ref)
+        if not ref_version or ref_version in LOCALLY_BUILT_TAGS or ref_name != image_name:
+            continue
+        if ref_version.startswith("stackdev-"):
+            # A stackdev version identifies a local development build; it is never published.
+            continue
+        if _strip_registry_host(ref) == ref:
+            local_versions.add(ref_version)
+        else:
+            qualified.append((ref_version, ref))
+    matches = sorted(ref for ref_version, ref in qualified if ref_version in local_versions)
+    return matches[0] if matches else None
+
+
+def resolve_image_for_deployment(image: str, image_registry: str, deployment_id: str) -> str:
+    """Return the image reference a (non-kind) k8s pod spec should use.
+
+    Images not tagged as locally built are pulled exactly as the pod file names them.
+    A locally built image is redirected at the deployment's staging registry when the
+    spec configures one (matching what push-images uploads); otherwise its published
+    registry-qualified reference is used.  If neither exists the deployment cannot
+    work, so fail now with the remedy rather than as an ImagePullBackOff later.
+    """
+    _, image_version = _split_image_reference(image)
+    if image_version not in LOCALLY_BUILT_TAGS:
+        return image
+    if image_registry:
+        return remote_tag_for_image_unique(image, image_registry, deployment_id)
+    published = _published_reference_for_image(image)
+    if published:
+        log_debug(f"Using published image {published} for {image}")
+        return published
+    error_exit(
+        f"Cannot resolve image {image} for deployment: it is not published to a registry and"
+        f" the spec has no image-registry to stage it through.  Either publish it"
+        f" (stack prepare --publish-images --image-registry <url>), or add an image registry"
+        f" to the deployment (stack init --image-registry <url> ...) and upload the image with"
+        f" 'stack manage --dir <deployment-dir> push-images'.  If the stack has not been"
+        f" prepared on this machine, run 'stack prepare' first."
+    )
+
+
 # TODO: needs lots of error handling
 def push_images_operation(command_context: DeployCommandContext, deployment_context: DeploymentContext):
     # Get the list of images for the stack
     cluster_context = command_context.cluster_context
     images: Set[str] = images_for_deployment(cluster_context.compose_files)
     # Tag the images for the remote repo
-    remote_repo_url = deployment_context.spec.obj[constants.image_registry_key]
+    remote_repo_url = deployment_context.spec.obj.get(constants.image_registry_key)
+    if not remote_repo_url:
+        error_exit(
+            "The spec has no image-registry to push to."
+            "  Re-run 'stack init' with --image-registry <url> to configure one."
+        )
     docker = DockerClient()
     for image in images:
         if _image_needs_pushed(image):

--- a/src/stack/deploy/k8s/cluster_info.py
+++ b/src/stack/deploy/k8s/cluster_info.py
@@ -44,7 +44,7 @@ from stack.deploy.deploy_types import DeployEnvVars
 from stack.deploy.deploy_util import convert_to_seconds
 from stack.deploy.k8s.helpers import DEFAULT_K8S_NAMESPACE
 from stack.deploy.spec import Spec, Resources, ResourceLimits
-from stack.deploy.images import remote_tag_for_image_unique
+from stack.deploy.images import resolve_image_for_deployment
 from stack.deploy.k8s import gateway
 
 
@@ -424,13 +424,14 @@ class ClusterInfo:
                             failure_threshold=int(healthcheck.get("retries", "3")),
                         )
 
-                # Re-write the image tag for remote deployment
+                # Re-write the image reference for remote deployment.
+                # A kind cluster with no staging registry gets local images loaded
+                # directly into it, so the local reference is the right one there.
                 # Note self.app_name has the same value as deployment_id
-                image_to_use = (
-                    remote_tag_for_image_unique(image, self.spec.get_image_registry(), self.app_name)
-                    if self.spec.get_image_registry() is not None
-                    else image
-                )
+                if self.spec.get_image_registry() is None and self.spec.is_kind_deployment():
+                    image_to_use = image
+                else:
+                    image_to_use = resolve_image_for_deployment(image, self.spec.get_image_registry(), self.app_name)
                 volume_mounts = volume_mounts_for_service(self.parsed_pod_yaml_map, service_name)
                 resources = self.spec.get_container_resources(service_name)
                 if not resources:

--- a/tests/unit/test_images.py
+++ b/tests/unit/test_images.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http:#www.gnu.org/licenses/>.
 
-"""Tests for rewriting local image tags into remote-registry tags.
+"""Tests for resolving local image tags into the references a deployment pulls.
 
 These decide what image a k8s deployment actually pulls, so a wrong answer here shows
 up as an ImagePullBackOff with no indication of which rewrite was at fault.
@@ -23,13 +23,17 @@ import pytest
 
 from stack.deploy.images import (
     _image_needs_pushed,
+    _published_reference_for_image,
     _remote_tag_for_image,
+    _strip_registry_host,
     remote_tag_for_image_unique,
+    resolve_image_for_deployment,
 )
 
 
 REGISTRY = "registry.example.com/org"
 DEPLOYMENT_ID = "stack-0123456789abcdef"
+HASH = "0123456789abcdef0123456789abcdef01234567"
 
 
 @pytest.mark.parametrize(
@@ -49,14 +53,31 @@ def test_image_needs_pushed(image, expected):
 
 
 @pytest.mark.parametrize(
+    "name, expected",
+    [
+        # A first component with a '.', a ':' or exactly "localhost" is a registry host.
+        ("ghcr.io/someorg/nginx", "someorg/nginx"),
+        ("localhost:5000/nginx", "nginx"),
+        ("localhost/nginx", "nginx"),
+        # Anything else is an org, which is part of the image's identity.
+        ("someorg/nginx", "someorg/nginx"),
+        ("nginx", "nginx"),
+    ],
+)
+def test_strip_registry_host(name, expected):
+    assert _strip_registry_host(name) == expected
+
+
+@pytest.mark.parametrize(
     "image, expected",
     [
         # Locally built tags are redirected at the remote registry...
         ("nginx:stack", f"{REGISTRY}/nginx:deploy"),
         ("nginx:local", f"{REGISTRY}/nginx:deploy"),
-        # ...and the org component of a two-part name is dropped, since the remote
-        # registry URL already carries its own org.
-        ("someorg/nginx:stack", f"{REGISTRY}/nginx:deploy"),
+        # ...keeping the org component, which is part of the image's identity (and
+        # required by registries like ghcr), but not any host, since the remote
+        # registry URL carries its own.
+        ("someorg/nginx:stack", f"{REGISTRY}/someorg/nginx:deploy"),
         # Anything else is pulled exactly as named.
         ("nginx:latest", "nginx:latest"),
         ("someorg/nginx:1.27", "someorg/nginx:1.27"),
@@ -73,7 +94,7 @@ def test_remote_tag_for_image(image, expected):
         # two deployments of the same stack do not collide on one remote tag.
         ("nginx:stack", f"{REGISTRY}/nginx:deploy-89abcdef"),
         ("nginx:local", f"{REGISTRY}/nginx:deploy-89abcdef"),
-        ("someorg/nginx:stack", f"{REGISTRY}/nginx:deploy-89abcdef"),
+        ("someorg/nginx:stack", f"{REGISTRY}/someorg/nginx:deploy-89abcdef"),
         ("nginx:latest", "nginx:latest"),
         ("someorg/nginx:1.27", "someorg/nginx:1.27"),
     ],
@@ -89,9 +110,9 @@ def test_remote_tag_for_image_unique(image, expected):
         ("docker.io/library/nginx:1.27", "docker.io/library/nginx:1.27"),
         ("ghcr.io/example/nginx:1.27", "ghcr.io/example/nginx:1.27"),
         # A stack-built image that already lives in a registry is still redirected at
-        # this deployment's registry, under its bare name.
-        ("ghcr.io/example/nginx:stack", f"{REGISTRY}/nginx:deploy-89abcdef"),
-        ("ghcr.io/example/nginx:local", f"{REGISTRY}/nginx:deploy-89abcdef"),
+        # this deployment's registry: the host is replaced, the org kept.
+        ("ghcr.io/example/nginx:stack", f"{REGISTRY}/example/nginx:deploy-89abcdef"),
+        ("ghcr.io/example/nginx:local", f"{REGISTRY}/example/nginx:deploy-89abcdef"),
     ],
 )
 def test_registry_qualified_image_reference(image, expected):
@@ -126,12 +147,127 @@ def test_digest_pinned_image_reference_left_alone():
 @pytest.mark.parametrize(
     "image, expected",
     [
-        ("ghcr.io/example/nginx:stack", f"{REGISTRY}/nginx:deploy"),
+        ("ghcr.io/example/nginx:stack", f"{REGISTRY}/example/nginx:deploy"),
         ("ghcr.io/example/nginx:1.27", "ghcr.io/example/nginx:1.27"),
         ("localhost:5000/nginx:stack", f"{REGISTRY}/nginx:deploy"),
         ("nginx", "nginx"),
     ],
 )
 def test_remote_tag_for_image_handles_the_same_reference_forms(image, expected):
-    # The non-unique rewriter shared the same parse, so it needs the same coverage.
+    # The non-unique rewriter shares the same parse, so it needs the same coverage.
     assert _remote_tag_for_image(image, REGISTRY) == expected
+
+
+class _FakeImage:
+    def __init__(self, repo_tags):
+        self.repo_tags = repo_tags
+
+
+class _FakeDockerClient:
+    """Stands in for DockerClient in images.py; serves one image's repo_tags."""
+
+    _repo_tags = None
+
+    def __init__(self):
+        self.image = self
+
+    def inspect(self, image):
+        if self._repo_tags is None:
+            raise Exception(f"No such image: {image}")
+        return _FakeImage(self._repo_tags)
+
+
+@pytest.fixture
+def local_repo_tags(monkeypatch):
+    def _set(repo_tags):
+        _FakeDockerClient._repo_tags = repo_tags
+        monkeypatch.setattr("stack.deploy.images.DockerClient", _FakeDockerClient)
+
+    yield _set
+    _FakeDockerClient._repo_tags = None
+
+
+def test_published_reference_found_from_prepare_cross_tags(local_repo_tags):
+    # The tag set stack prepare leaves behind after pulling a prebuilt image.
+    local_repo_tags(
+        [
+            f"exampleorg/myapp:{HASH}",
+            "exampleorg/myapp:stack",
+            "exampleorg/myapp:local",
+            f"ghcr.io/exampleorg/myapp:{HASH}",
+        ]
+    )
+    assert _published_reference_for_image("exampleorg/myapp:stack") == f"ghcr.io/exampleorg/myapp:{HASH}"
+
+
+def test_published_reference_ignores_staging_deploy_tags(local_repo_tags):
+    # A deployment-private staging tag has no unqualified counterpart, so it must not
+    # be mistaken for a published image.
+    local_repo_tags(
+        [
+            f"exampleorg/myapp:{HASH}",
+            "exampleorg/myapp:stack",
+            "registry.example.com/exampleorg/myapp:deploy-89abcdef",
+        ]
+    )
+    assert _published_reference_for_image("exampleorg/myapp:stack") is None
+
+
+def test_published_reference_ignores_stackdev_versions(local_repo_tags):
+    # A stackdev version identifies a local development build; it is never published.
+    local_repo_tags(
+        [
+            "exampleorg/myapp:stackdev-abc123",
+            "exampleorg/myapp:stack",
+            "ghcr.io/exampleorg/myapp:stackdev-abc123",
+        ]
+    )
+    assert _published_reference_for_image("exampleorg/myapp:stack") is None
+
+
+def test_published_reference_ignores_other_images_tags(local_repo_tags):
+    # A qualified tag for a different image name proves nothing about this one.
+    local_repo_tags(
+        [
+            "exampleorg/myapp:stack",
+            f"exampleorg/myapp:{HASH}",
+            f"ghcr.io/otherorg/otherapp:{HASH}",
+        ]
+    )
+    assert _published_reference_for_image("exampleorg/myapp:stack") is None
+
+
+def test_published_reference_none_when_image_absent(local_repo_tags):
+    local_repo_tags(None)  # inspect raises, as when the image was never prepared
+    assert _published_reference_for_image("exampleorg/myapp:stack") is None
+
+
+def test_resolve_prefers_staging_registry_when_configured(local_repo_tags):
+    # With a staging registry in the spec, the deployment pulls what push-images
+    # uploads, even if the image is also published somewhere.
+    local_repo_tags(["exampleorg/myapp:stack", f"ghcr.io/exampleorg/myapp:{HASH}", f"exampleorg/myapp:{HASH}"])
+    assert (
+        resolve_image_for_deployment("exampleorg/myapp:stack", REGISTRY, DEPLOYMENT_ID)
+        == f"{REGISTRY}/exampleorg/myapp:deploy-89abcdef"
+    )
+
+
+def test_resolve_uses_published_reference_without_staging_registry(local_repo_tags):
+    local_repo_tags(["exampleorg/myapp:stack", f"ghcr.io/exampleorg/myapp:{HASH}", f"exampleorg/myapp:{HASH}"])
+    assert (
+        resolve_image_for_deployment("exampleorg/myapp:stack", None, DEPLOYMENT_ID)
+        == f"ghcr.io/exampleorg/myapp:{HASH}"
+    )
+
+
+def test_resolve_leaves_upstream_images_alone(local_repo_tags):
+    local_repo_tags(None)
+    assert resolve_image_for_deployment("postgres:16", None, DEPLOYMENT_ID) == "postgres:16"
+
+
+def test_resolve_fails_fast_when_image_is_unreachable(local_repo_tags):
+    # Locally built, not published, and no staging registry: the deployment cannot
+    # work, so this must error at create time, not ImagePullBackOff later.
+    local_repo_tags(["exampleorg/myapp:stack", "exampleorg/myapp:stackdev-abc123"])
+    with pytest.raises(SystemExit):
+        resolve_image_for_deployment("exampleorg/myapp:stack", None, DEPLOYMENT_ID)

--- a/tests/unit/test_k8s_explain.py
+++ b/tests/unit/test_k8s_explain.py
@@ -104,6 +104,10 @@ def build_deployment(tmp_path, isolated_env, deploy_to="k8s", extra_init_args=()
         kube_config.write_text("apiVersion: v1\n")
         init_args += ["--kube-config", str(kube_config)]
     init_args += list(extra_init_args)
+    if deploy_to == "k8s" and "--image-registry" not in init_args:
+        # The fixture image is locally built and unpublished, so a k8s deployment
+        # needs a staging registry to be resolvable at all.
+        init_args += ["--image-registry", "registry.example.com/org"]
 
     result = run_stack(init_args, isolated_env, cwd=tmp_path)
     assert result.returncode == 0, f"init failed:\n{result.stdout}\n{result.stderr}"

--- a/tests/unit/test_k8s_objects.py
+++ b/tests/unit/test_k8s_objects.py
@@ -38,14 +38,23 @@ MINIMAL_POD = """\
     """
 
 
+REGISTRY = "registry.example.com/org"
+
+
 def k8s_spec(**overrides):
-    """A k8s deployment spec for the single-service pod above."""
+    """A k8s deployment spec for the single-service pod above.
+
+    A staging image-registry is configured by default, since without one every
+    locally built image must be published somewhere the cluster can pull from
+    (which these fixture images are not).  Override with None to remove a key.
+    """
     spec = {
         "stack": "teststack",
         "deploy-to": "k8s",
+        "image-registry": REGISTRY,
     }
     spec.update(overrides)
-    return spec
+    return {k: v for k, v in spec.items() if v is not None}
 
 
 # ---------------------------------------------------------------------------
@@ -733,8 +742,66 @@ def test_liveness_probe_time_units_converted(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_image_left_alone_without_registry(tmp_path):
-    cluster_info = make_cluster_info(tmp_path, MINIMAL_POD, k8s_spec())
+class _FakeImagesDockerClient:
+    """Stands in for DockerClient in stack.deploy.images; serves one image's repo_tags."""
+
+    repo_tags = None
+
+    def __init__(self):
+        self.image = self
+
+    def inspect(self, image):
+        if self.repo_tags is None:
+            raise Exception(f"No such image: {image}")
+
+        class _Image:
+            repo_tags = self.repo_tags
+
+        return _Image()
+
+
+PUBLISHED_HASH = "0123456789abcdef0123456789abcdef01234567"
+
+PUBLISHED_POD = """\
+    services:
+      web:
+        image: exampleorg/myapp:stack
+        ports:
+          - "80"
+    """
+
+
+def test_published_image_used_without_registry(tmp_path, monkeypatch):
+    # No staging registry in the spec, but prepare's cross-tags show the image is
+    # published: the pod pulls the registry-qualified reference directly.
+    _FakeImagesDockerClient.repo_tags = [
+        "exampleorg/myapp:stack",
+        f"exampleorg/myapp:{PUBLISHED_HASH}",
+        f"ghcr.io/exampleorg/myapp:{PUBLISHED_HASH}",
+    ]
+    monkeypatch.setattr("stack.deploy.images.DockerClient", _FakeImagesDockerClient)
+    cluster_info = make_cluster_info(tmp_path, PUBLISHED_POD, k8s_spec(**{"image-registry": None}))
+
+    container = k8s_dict(cluster_info.get_deployments()[0])["spec"]["template"]["spec"]["containers"][0]
+    assert container["image"] == f"ghcr.io/exampleorg/myapp:{PUBLISHED_HASH}"
+
+
+def test_unpublished_image_without_registry_fails_fast(tmp_path, monkeypatch):
+    # Locally built, unpublished, and no staging registry: the cluster could never
+    # pull this, so object generation must error rather than emit a doomed pod.
+    _FakeImagesDockerClient.repo_tags = None
+    monkeypatch.setattr("stack.deploy.images.DockerClient", _FakeImagesDockerClient)
+    cluster_info = make_cluster_info(tmp_path, MINIMAL_POD, k8s_spec(**{"image-registry": None}))
+
+    with pytest.raises(SystemExit):
+        cluster_info.get_deployments()
+
+
+def test_kind_without_registry_uses_local_image(tmp_path):
+    # kind gets local images loaded directly into the cluster, so the local
+    # reference is the right one there.
+    spec = k8s_spec(**{"image-registry": None, "deploy-to": "k8s-kind"})
+    cluster_info = make_cluster_info(tmp_path, MINIMAL_POD, spec)
 
     container = k8s_dict(cluster_info.get_deployments()[0])["spec"]["template"]["spec"]["containers"][0]
     assert container["image"] == "nginx:local"
@@ -767,8 +834,9 @@ def test_released_two_part_image_not_retagged_for_registry(tmp_path):
     [
         # Released images are pulled as named, however they are qualified.
         ("ghcr.io/example/nginx:1.27", "ghcr.io/example/nginx:1.27"),
-        # A stack-built image is redirected at the deployment's registry either way.
-        ("ghcr.io/example/nginx:stack", "registry.example.com/org/nginx:deploy-89abcdef"),
+        # A stack-built image is redirected at the deployment's registry either way:
+        # the host is replaced, the org kept.
+        ("ghcr.io/example/nginx:stack", "registry.example.com/org/example/nginx:deploy-89abcdef"),
     ],
 )
 def test_registry_qualified_image_handled(tmp_path, image, expected):


### PR DESCRIPTION
Also add full documentation for stack's container image naming/versioning mechanisms.